### PR TITLE
Fix flash of tooltip content on DOM using SSR + JSX content

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -3,39 +3,41 @@ import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import tippy from 'tippy.js'
 
+const isBrowser = typeof window !== 'undefined'
+
 const getNativeTippyProps = props => {
   const { children, onCreate, ...tippyProps } = props
   return tippyProps
 }
 
 class Tippy extends React.Component {
-  content = React.createRef()
+  state = { isMounted: false }
 
-  static propTypes = {
-    content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
-      .isRequired,
-    children: PropTypes.element.isRequired
+  container = isBrowser && document.createElement('div')
+
+  get isReactElementContent() {
+    return React.isValidElement(this.props.content)
   }
 
-  getContent() {
-    return React.isValidElement(this.props.content)
-      ? this.content.current
-      : this.props.content
+  get content() {
+    return this.isReactElementContent ? this.container : this.props.content
+  }
+
+  get options() {
+    return {
+      ...getNativeTippyProps(this.props),
+      content: this.content
+    }
   }
 
   componentDidMount() {
-    this.tip = tippy.one(ReactDOM.findDOMNode(this), {
-      ...getNativeTippyProps(this.props),
-      content: this.getContent()
-    })
+    this.setState({ isMounted: true })
+    this.tip = tippy.one(ReactDOM.findDOMNode(this), this.options)
     this.props.onCreate && this.props.onCreate(this.tip)
   }
 
   componentDidUpdate() {
-    this.tip.set({
-      ...getNativeTippyProps(this.props),
-      content: this.getContent()
-    })
+    this.tip.set(this.options)
   }
 
   componentWillUnmount() {
@@ -49,9 +51,10 @@ class Tippy extends React.Component {
     return (
       <React.Fragment>
         {this.props.children}
-        {React.isValidElement(this.props.content) && (
-          <div ref={this.content}>{this.props.content}</div>
-        )}
+        {isBrowser &&
+          this.isReactElementContent &&
+          this.state.isMounted &&
+          ReactDOM.createPortal(this.props.content, this.container)}
       </React.Fragment>
     )
   }

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -15,6 +15,13 @@ class Tippy extends React.Component {
 
   container = isBrowser && document.createElement('div')
 
+  static propTypes = {
+    content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+      .isRequired,
+    children: PropTypes.element.isRequired,
+    onCreate: PropTypes.func
+  }
+
   get isReactElementContent() {
     return React.isValidElement(this.props.content)
   }


### PR DESCRIPTION
Apparently [we need to use `setState()` because of a warning](https://github.com/facebook/react/issues/13097#issuecomment-405658104) created when using a portal with SSR. All tests are passing, behavior appears to be exactly the same

Reviews?

@KubaJastrz
@elya