### PR TITLE
Add isVisible and isEnabled props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Instance, Props } from 'tippy.js';
+import React from 'react'
+import { Instance, Props } from 'tippy.js'
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
@@ -7,6 +7,8 @@ export interface TippyProps extends Omit<Props, 'content'> {
   content: React.ReactNode | string
   children: React.ReactNode
   onCreate?: (tip: Instance) => void
+  isVisible?: boolean
+  isEnabled?: boolean
 }
 
 export default class Tippy extends React.Component<TippyProps> {}

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -7,14 +7,13 @@ import tippy from 'tippy.js'
 const REACT_ONLY_PROPS = ['children', 'onCreate', 'isVisible', 'isEnabled']
 
 // Avoid Babel's large '_objectWithoutProperties' helper function.
-const getNativeTippyProps = props => {
-  const nativeProps = {}
-  for (const prop in props) {
-    if (REACT_ONLY_PROPS.indexOf(prop) === -1) {
-      nativeProps[prop] = props[prop]
+function getNativeTippyProps(props) {
+  return Object.keys(props).reduce((acc, key) => {
+    if (REACT_ONLY_PROPS.indexOf(key) === -1) {
+      acc[key] = props[key]
     }
-  }
-  return nativeProps
+    return acc
+  }, {})
 }
 
 class Tippy extends React.Component {

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -49,15 +49,17 @@ class Tippy extends React.Component {
 
     this.tip = tippy.one(ReactDOM.findDOMNode(this), this.options)
 
-    if (this.props.onCreate) {
-      this.props.onCreate(this.tip)
+    const { onCreate, isEnabled, isVisible } = this.props
+
+    if (onCreate) {
+      onCreate(this.tip)
     }
 
-    if (this.props.isEnabled === false) {
+    if (isEnabled === false) {
       this.tip.disable()
     }
 
-    if (this.isManualTrigger && this.props.isVisible === true) {
+    if (this.isManualTrigger && isVisible === true) {
       this.tip.show()
     }
   }
@@ -65,16 +67,18 @@ class Tippy extends React.Component {
   componentDidUpdate() {
     this.tip.set(this.options)
 
-    if (this.props.isEnabled === true) {
+    const { isEnabled, isVisible } = this.props
+
+    if (isEnabled === true) {
       this.tip.enable()
-    } else if (this.props.isEnabled === false) {
+    } else if (isEnabled === false) {
       this.tip.disable()
     }
 
     if (this.isManualTrigger) {
-      if (this.props.isVisible === true) {
+      if (isVisible === true) {
         this.tip.show()
-      } else if (this.props.isVisible === false) {
+      } else if (isVisible === false) {
         this.tip.hide()
       }
     }

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -26,7 +26,9 @@ class Tippy extends React.Component {
     content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
       .isRequired,
     children: PropTypes.element.isRequired,
-    onCreate: PropTypes.func
+    onCreate: PropTypes.func,
+    isVisible: PropTypes.bool,
+    isEnabled: PropTypes.bool
   }
 
   get isReactElementContent() {

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import tippy from 'tippy.js'
 
-// Avoid Babel's large '_objectWithoutProperties' helper function
+// These props are not native to `tippy.js` and are specific to React only.
+const REACT_ONLY_PROPS = ['children', 'onCreate', 'isVisible', 'isEnabled']
+
+// Avoid Babel's large '_objectWithoutProperties' helper function.
 const getNativeTippyProps = props => {
   const nativeProps = {}
   for (const prop in props) {
-    if (prop !== 'children' && prop !== 'onCreate') {
+    if (REACT_ONLY_PROPS.indexOf(prop) === -1) {
       nativeProps[prop] = props[prop]
     }
   }
@@ -37,14 +40,44 @@ class Tippy extends React.Component {
     }
   }
 
+  get isManualTrigger() {
+    return this.props.trigger === 'manual'
+  }
+
   componentDidMount() {
     this.setState({ isMounted: true })
+
     this.tip = tippy.one(ReactDOM.findDOMNode(this), this.options)
-    this.props.onCreate && this.props.onCreate(this.tip)
+
+    if (this.props.onCreate) {
+      this.props.onCreate(this.tip)
+    }
+
+    if (this.props.isEnabled === false) {
+      this.tip.disable()
+    }
+
+    if (this.isManualTrigger && this.props.isVisible === true) {
+      this.tip.show()
+    }
   }
 
   componentDidUpdate() {
     this.tip.set(this.options)
+
+    if (this.props.isEnabled === true) {
+      this.tip.enable()
+    } else if (this.props.isEnabled === false) {
+      this.tip.disable()
+    }
+
+    if (this.isManualTrigger) {
+      if (this.props.isVisible === true) {
+        this.tip.show()
+      } else if (this.props.isVisible === false) {
+        this.tip.hide()
+      }
+    }
   }
 
   componentWillUnmount() {

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -72,24 +72,24 @@ class Tippy extends React.Component {
 
     if (isEnabled === true) {
       this.tip.enable()
-    } else if (isEnabled === false) {
+    }
+    if (isEnabled === false) {
       this.tip.disable()
     }
 
     if (this.isManualTrigger) {
       if (isVisible === true) {
         this.tip.show()
-      } else if (isVisible === false) {
+      }
+      if (isVisible === false) {
         this.tip.hide()
       }
     }
   }
 
   componentWillUnmount() {
-    if (this.tip) {
-      this.tip.destroy()
-      this.tip = null
-    }
+    this.tip.destroy()
+    this.tip = null
   }
 
   render() {

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -144,34 +144,34 @@ describe('<Tippy />', () => {
   }
 
   test('props.isEnabled true initially', done => {
-    const EnabledInit = initialIsEnabledAs(true)
-    const enabledWrapper = mount(<EnabledInit />)
-    const enabledTip = enabledWrapper.getDOMNode()._tippy
+    const Component = initialIsEnabledAs(true)
+    const wrapper = mount(<Component />)
+    const tip = wrapper.getDOMNode()._tippy
 
-    expect(enabledTip.state.isEnabled).toBe(true)
+    expect(tip.state.isEnabled).toBe(true)
 
-    enabledWrapper.setState({ isEnabled: true }, () => {
-      expect(enabledTip.state.isEnabled).toBe(true)
-      enabledWrapper.setState({ isEnabled: false }, () => {
-        expect(enabledTip.state.isEnabled).toBe(false)
-        enabledWrapper.unmount()
+    wrapper.setState({ isEnabled: true }, () => {
+      expect(tip.state.isEnabled).toBe(true)
+      wrapper.setState({ isEnabled: false }, () => {
+        expect(tip.state.isEnabled).toBe(false)
+        wrapper.unmount()
         done()
       })
     })
   })
 
   test('props.isEnabled false initially', done => {
-    const DisabledInit = initialIsEnabledAs(false)
-    const disabledWrapper = mount(<DisabledInit />)
-    const disabledTip = disabledWrapper.getDOMNode()._tippy
+    const Component = initialIsEnabledAs(false)
+    const wrapper = mount(<Component />)
+    const tip = wrapper.getDOMNode()._tippy
 
-    expect(disabledTip.state.isEnabled).toBe(false)
+    expect(tip.state.isEnabled).toBe(false)
 
-    disabledWrapper.setState({ isEnabled: false }, () => {
-      expect(disabledTip.state.isEnabled).toBe(false)
-      disabledWrapper.setState({ isEnabled: true }, () => {
-        expect(disabledTip.state.isEnabled).toBe(true)
-        disabledWrapper.unmount()
+    wrapper.setState({ isEnabled: false }, () => {
+      expect(tip.state.isEnabled).toBe(false)
+      wrapper.setState({ isEnabled: true }, () => {
+        expect(tip.state.isEnabled).toBe(true)
+        wrapper.unmount()
         done()
       })
     })
@@ -197,32 +197,34 @@ describe('<Tippy />', () => {
   }
 
   test('props.isVisible true initially', done => {
-    const VisibleInit = initialIsVisibleAs(true)
-    const visibleWrapper = mount(<VisibleInit />)
-    const visibleTip = visibleWrapper.getDOMNode()._tippy
+    const Component = initialIsVisibleAs(true)
+    const wrapper = mount(<Component />)
+    const tip = wrapper.getDOMNode()._tippy
 
-    expect(visibleTip.state.isVisible).toBe(true)
+    expect(tip.state.isVisible).toBe(true)
 
-    visibleWrapper.setState({ isVisible: true }, () => {
-      expect(visibleTip.state.isVisible).toBe(true)
-      visibleWrapper.setState({ isVisible: false }, () => {
-        expect(visibleTip.state.isVisible).toBe(false)
+    wrapper.setState({ isVisible: true }, () => {
+      expect(tip.state.isVisible).toBe(true)
+      wrapper.setState({ isVisible: false }, () => {
+        expect(tip.state.isVisible).toBe(false)
+        wrapper.unmount()
         done()
       })
     })
   })
 
   test('props.isVisible false initially', done => {
-    const HiddenInit = initialIsVisibleAs(false)
-    const hiddenWrapper = mount(<HiddenInit />)
-    const hiddenTip = hiddenWrapper.getDOMNode()._tippy
+    const Component = initialIsVisibleAs(false)
+    const wrapper = mount(<Component />)
+    const tip = wrapper.getDOMNode()._tippy
 
-    expect(hiddenTip.state.isVisible).toBe(false)
+    expect(tip.state.isVisible).toBe(false)
 
-    hiddenWrapper.setState({ isVisible: false }, () => {
-      expect(hiddenTip.state.isVisible).toBe(false)
-      hiddenWrapper.setState({ isVisible: true }, () => {
-        expect(hiddenTip.state.isVisible).toBe(true)
+    wrapper.setState({ isVisible: false }, () => {
+      expect(tip.state.isVisible).toBe(false)
+      wrapper.setState({ isVisible: true }, () => {
+        expect(tip.state.isVisible).toBe(true)
+        wrapper.unmount()
         done()
       })
     })

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -127,4 +127,104 @@ describe('<Tippy />', () => {
       ).includes('<div>Tooltip</div>')
     ).toBe(false)
   })
+
+  function initialIsEnabledAs(bool) {
+    return class extends React.Component {
+      state = {
+        isEnabled: bool
+      }
+      render() {
+        return (
+          <Tippy content="tooltip" isEnabled={this.state.isEnabled}>
+            <button />
+          </Tippy>
+        )
+      }
+    }
+  }
+
+  test('props.isEnabled true initially', done => {
+    const EnabledInit = initialIsEnabledAs(true)
+    const enabledWrapper = mount(<EnabledInit />)
+    const enabledTip = enabledWrapper.getDOMNode()._tippy
+
+    expect(enabledTip.state.isEnabled).toBe(true)
+
+    enabledWrapper.setState({ isEnabled: true }, () => {
+      expect(enabledTip.state.isEnabled).toBe(true)
+      enabledWrapper.setState({ isEnabled: false }, () => {
+        expect(enabledTip.state.isEnabled).toBe(false)
+        enabledWrapper.unmount()
+        done()
+      })
+    })
+  })
+
+  test('props.isEnabled false initially', done => {
+    const DisabledInit = initialIsEnabledAs(false)
+    const disabledWrapper = mount(<DisabledInit />)
+    const disabledTip = disabledWrapper.getDOMNode()._tippy
+
+    expect(disabledTip.state.isEnabled).toBe(false)
+
+    disabledWrapper.setState({ isEnabled: false }, () => {
+      expect(disabledTip.state.isEnabled).toBe(false)
+      disabledWrapper.setState({ isEnabled: true }, () => {
+        expect(disabledTip.state.isEnabled).toBe(true)
+        disabledWrapper.unmount()
+        done()
+      })
+    })
+  })
+
+  function initialIsVisibleAs(bool) {
+    return class extends React.Component {
+      state = {
+        isVisible: bool
+      }
+      render() {
+        return (
+          <Tippy
+            content="tooltip"
+            trigger="manual"
+            isVisible={this.state.isVisible}
+          >
+            <button />
+          </Tippy>
+        )
+      }
+    }
+  }
+
+  test('props.isVisible true initially', done => {
+    const VisibleInit = initialIsVisibleAs(true)
+    const visibleWrapper = mount(<VisibleInit />)
+    const visibleTip = visibleWrapper.getDOMNode()._tippy
+
+    expect(visibleTip.state.isVisible).toBe(true)
+
+    visibleWrapper.setState({ isVisible: true }, () => {
+      expect(visibleTip.state.isVisible).toBe(true)
+      visibleWrapper.setState({ isVisible: false }, () => {
+        expect(visibleTip.state.isVisible).toBe(false)
+        done()
+      })
+    })
+  })
+
+  test('props.isVisible false initially', done => {
+    const HiddenInit = initialIsVisibleAs(false)
+    const hiddenWrapper = mount(<HiddenInit />)
+    const hiddenTip = hiddenWrapper.getDOMNode()._tippy
+
+    expect(hiddenTip.state.isVisible).toBe(false)
+
+    hiddenWrapper.setState({ isVisible: false }, () => {
+      expect(hiddenTip.state.isVisible).toBe(false)
+      hiddenWrapper.setState({ isVisible: true }, () => {
+        expect(hiddenTip.state.isVisible).toBe(true)
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Wraps Tippy's `.enable()`, `.disable()`, `.show()`, and `.hide()` methods using props.

`isVisible` must be accompanied by `trigger="manual"`

For some reason the `isVisible` tests are failing. Anyone want to take a look? Seems like `trigger="manual"` causes a problem but I have no idea why.

Manual dev environment tests show it working as expected