### PR TITLE
Narrow content and children types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,8 +4,8 @@ import { Instance, Props } from 'tippy.js';
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 export interface TippyProps extends Omit<Props, 'content'> {
-  content: React.ReactNode | string
-  children: React.ReactNode
+  content: React.ReactElement<any> | string
+  children: React.ReactElement<any>
   onCreate?: (tip: Instance) => void
 }
 


### PR DESCRIPTION
I believe #18 was merged too hastily. `React.ReactNode` isn't the correct type to use here because it disagrees with how [propTypes are defined](https://github.com/atomiks/tippy.js-react/blob/master/src/Tippy.js#L22-L27). Using `React.ReactNode` allows for invalid code such as this:

```jsx
<>
  <Tippy content={null}>
    <div />
  </Tippy>
  <Tippy content="foo">
    {null}
  </Tippy>
</>
```

The second `Tippy` element here will fail at runtime.