### PR TITLE
Import React as module object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { Instance, Props } from 'tippy.js'
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>


### PR DESCRIPTION
React does not use default export or named export, so the import did not work as expected.

Solves this issue when trying to include the library to TS project:

> TS2605: JSX element type 'Tippy' is not a constructor function for JSX elements. Property 'render' is missing in type 'Tippy'