### PR TITLE
Support render props alternative due to deprecated findDOMNode()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,9 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 export interface TippyProps extends Omit<Props, 'content'> {
   content: React.ReactElement<any> | string
-  children: (
-    ref: React.RefObject
-  ) => React.ReactElement<any> | React.ReactElement<any>
+  children:
+    | ((ref: React.RefObject) => React.ReactElement<any>)
+    | React.ReactElement<any>
   onCreate?: (tip: Instance) => void
   isVisible?: boolean
   isEnabled?: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,9 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 export interface TippyProps extends Omit<Props, 'content'> {
   content: React.ReactElement<any> | string
-  children: React.ReactElement<any>
+  children: (
+    ref: React.RefObject
+  ) => React.ReactElement<any> | React.ReactElement<any>
   onCreate?: (tip: Instance) => void
   isVisible?: boolean
   isEnabled?: boolean

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "tippy.js": "^3.2.0"
   },
   "peerDependencies": {
-    "react": ">=16.2",
-    "react-dom": ">=16.2"
+    "react": ">=16.3",
+    "react-dom": ">=16.3"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -16,15 +16,22 @@ function getNativeTippyProps(props) {
   }, {})
 }
 
+function isFunction(value) {
+  return typeof value === 'function'
+}
+
 class Tippy extends React.Component {
   state = { isMounted: false }
 
   container = typeof document !== 'undefined' && document.createElement('div')
 
+  ref = React.createRef()
+
   static propTypes = {
     content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
       .isRequired,
-    children: PropTypes.element.isRequired,
+    children: PropTypes.oneOfType([PropTypes.element, PropTypes.func])
+      .isRequired,
     onCreate: PropTypes.func,
     isVisible: PropTypes.bool,
     isEnabled: PropTypes.bool
@@ -46,11 +53,14 @@ class Tippy extends React.Component {
   }
 
   componentDidMount() {
+    const { children, onCreate, isEnabled, isVisible } = this.props
+
     this.setState({ isMounted: true })
 
-    this.tip = tippy.one(ReactDOM.findDOMNode(this), this.options)
-
-    const { onCreate, isEnabled, isVisible } = this.props
+    this.tip = tippy.one(
+      isFunction(children) ? this.ref.current : ReactDOM.findDOMNode(this),
+      this.options
+    )
 
     if (onCreate) {
       onCreate(this.tip)
@@ -93,12 +103,14 @@ class Tippy extends React.Component {
   }
 
   render() {
+    const { children, content } = this.props
+
     return (
       <React.Fragment>
-        {this.props.children}
+        {isFunction(children) ? children(this.ref) : children}
         {this.isReactElementContent &&
           this.state.isMounted &&
-          ReactDOM.createPortal(this.props.content, this.container)}
+          ReactDOM.createPortal(content, this.container)}
       </React.Fragment>
     )
   }

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -202,4 +202,12 @@ describe('<Tippy />', () => {
     expect(button._tippy.state.isVisible).toBe(false)
     fireEvent.click(button)
   })
+
+  test('render prop ref', () => {
+    const { container } = render(
+      <Tippy content="tooltip">{ref => <button ref={ref} />}</Tippy>
+    )
+    const button = container.querySelector('button')
+    expect(button._tippy).toBeDefined()
+  })
 })


### PR DESCRIPTION
Continued from discussion in #27 

Until React supports refs on `Fragments` this seems to be required for strict mode. Anyone else want to chime in?