### PR TITLE
Lazy render

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ Popover.defaultProps = {
 import { Tooltip, Popover } from './Tippy'
 ```
 
+## LazyTippy
+
+If you need to show some hard component inside the tooltip, for better performance use this component.
+
+```jsx
+import { LazyTippy } from '@tippy.js/react'
+
+const App = () => (
+  <LazyTippy content={<SomeHardComponent />}>
+    <button>My button</button>
+  </LazyTippy>
+)
+```
+
 ## License
 
 MIT

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Tippy from '../src/Tippy'
+import Tippy from '../src/index'
 import 'tippy.js/dist/tippy.css'
 import './index.css'
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Tippy from '../src/index'
+import Tippy from '../src'
 import 'tippy.js/dist/tippy.css'
 import './index.css'
 

--- a/rollup.build.js
+++ b/rollup.build.js
@@ -16,7 +16,7 @@ const pluginMinify = minify({ comments: false })
 const pluginResolve = resolve()
 
 const rollupConfig = (...plugins) => ({
-  input: './src/Tippy.js',
+  input: './src/index.js',
   plugins: [pluginBabel, pluginResolve, ...plugins],
   external: ['tippy.js', 'react', 'react-dom', 'prop-types']
 })

--- a/src/LazyTippy.js
+++ b/src/LazyTippy.js
@@ -11,18 +11,14 @@ export class LazyTippy extends React.Component {
   }
 
   handleShow = e => {
-    this.setState({
-      isShow: true
-    })
+    this.setState({ isShow: true })
     if (this.props.onShow) {
       this.props.onShow(e)
     }
   }
 
   handleHidden = e => {
-    this.setState({
-      isShow: false
-    })
+    this.setState({ isShow: false })
     if (this.props.onHidden) {
       this.props.onHidden(e)
     }

--- a/src/LazyTippy.js
+++ b/src/LazyTippy.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Tippy from './Tippy'
+
+export class LazyTippy extends React.Component {
+  state = {
+    isShow: false
+  }
+
+  static propTypes = {
+    onShow: PropTypes.func,
+    onHidden: PropTypes.func
+  }
+
+  handleShow = e => {
+    this.setState({
+      isShow: true
+    })
+    if (this.props.onShow) {
+      this.props.onShow(e)
+    }
+  }
+
+  handleHidden = e => {
+    this.setState({
+      isShow: false
+    })
+    if (this.props.onHidden) {
+      this.props.onHidden(e)
+    }
+  }
+
+  render() {
+    return (
+      <Tippy
+        {...this.props}
+        onShow={this.handleShow}
+        onHidden={this.handleHidden}
+        content={this.state.isShow ? this.props.content : null}
+      />
+    )
+  }
+}

--- a/src/LazyTippy.js
+++ b/src/LazyTippy.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types'
 import Tippy from './Tippy'
 
 export class LazyTippy extends React.Component {
-  state = {
-    isShow: false
-  }
+  state = { isShow: false }
 
   static propTypes = {
     onShow: PropTypes.func,

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -17,7 +17,7 @@ function getNativeTippyProps(props) {
 }
 
 class Tippy extends React.Component {
-  state = { isMounted: false, isShow: false }
+  state = { isMounted: false }
 
   container = typeof document !== 'undefined' && document.createElement('div')
 
@@ -26,7 +26,6 @@ class Tippy extends React.Component {
     children: PropTypes.element.isRequired,
     onCreate: PropTypes.func,
     isVisible: PropTypes.bool,
-    lazyRender: PropTypes.bool,
     isEnabled: PropTypes.bool
   }
 

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -9,7 +9,7 @@ const REACT_ONLY_PROPS = [
   'onCreate',
   'isVisible',
   'isEnabled',
-  'lazyRender',
+  'lazyRender'
 ]
 
 // Avoid Babel's large '_objectWithoutProperties' helper function.
@@ -36,7 +36,7 @@ class Tippy extends React.Component {
     onHidden: PropTypes.func,
     isVisible: PropTypes.bool,
     lazyRender: PropTypes.bool,
-    isEnabled: PropTypes.bool,
+    isEnabled: PropTypes.bool
   }
 
   get isReactElementContent() {
@@ -49,9 +49,9 @@ class Tippy extends React.Component {
       ...(this.props.lazyRender &&
         !this.isManualTrigger && {
           onShow: this.handleShow,
-          onHidden: this.handleHidden,
+          onHidden: this.handleHidden
         }),
-      content: this.isReactElementContent ? this.container : this.props.content,
+      content: this.isReactElementContent ? this.container : this.props.content
     }
   }
 
@@ -111,7 +111,7 @@ class Tippy extends React.Component {
 
   handleShow = e => {
     this.setState({
-      isShow: true,
+      isShow: true
     })
     if (this.props.onShow) {
       this.props.onShow(e)
@@ -120,7 +120,7 @@ class Tippy extends React.Component {
 
   handleHidden = e => {
     this.setState({
-      isShow: false,
+      isShow: false
     })
     if (this.props.onHidden) {
       this.props.onHidden(e)

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -4,13 +4,7 @@ import PropTypes from 'prop-types'
 import tippy from 'tippy.js'
 
 // These props are not native to `tippy.js` and are specific to React only.
-const REACT_ONLY_PROPS = [
-  'children',
-  'onCreate',
-  'isVisible',
-  'isEnabled',
-  'lazyRender'
-]
+const REACT_ONLY_PROPS = ['children', 'onCreate', 'isVisible', 'isEnabled']
 
 // Avoid Babel's large '_objectWithoutProperties' helper function.
 function getNativeTippyProps(props) {
@@ -28,12 +22,9 @@ class Tippy extends React.Component {
   container = typeof document !== 'undefined' && document.createElement('div')
 
   static propTypes = {
-    content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
-      .isRequired,
+    content: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     children: PropTypes.element.isRequired,
     onCreate: PropTypes.func,
-    onShow: PropTypes.func,
-    onHidden: PropTypes.func,
     isVisible: PropTypes.bool,
     lazyRender: PropTypes.bool,
     isEnabled: PropTypes.bool
@@ -46,25 +37,12 @@ class Tippy extends React.Component {
   get options() {
     return {
       ...getNativeTippyProps(this.props),
-      ...(this.props.lazyRender &&
-        !this.isManualTrigger && {
-          onShow: this.handleShow,
-          onHidden: this.handleHidden
-        }),
       content: this.isReactElementContent ? this.container : this.props.content
     }
   }
 
   get isManualTrigger() {
     return this.props.trigger === 'manual'
-  }
-
-  get isCanRender() {
-    if (!this.props.lazyRender || this.isManualTrigger) {
-      return true
-    }
-
-    return this.state.isShow
   }
 
   componentDidMount() {
@@ -109,24 +87,6 @@ class Tippy extends React.Component {
     }
   }
 
-  handleShow = e => {
-    this.setState({
-      isShow: true
-    })
-    if (this.props.onShow) {
-      this.props.onShow(e)
-    }
-  }
-
-  handleHidden = e => {
-    this.setState({
-      isShow: false
-    })
-    if (this.props.onHidden) {
-      this.props.onHidden(e)
-    }
-  }
-
   componentWillUnmount() {
     this.tip.destroy()
     this.tip = null
@@ -138,10 +98,7 @@ class Tippy extends React.Component {
         {this.props.children}
         {this.isReactElementContent &&
           this.state.isMounted &&
-          ReactDOM.createPortal(
-            this.isCanRender ? this.props.content : null,
-            this.container
-          )}
+          ReactDOM.createPortal(this.props.content, this.container)}
       </React.Fragment>
     )
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+import Tippy from './Tippy'
+
+export * from './LazyTippy'
+export default Tippy

--- a/test/LazyTippy.test.js
+++ b/test/LazyTippy.test.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import { LazyTippy } from '../src'
+import ReactDOMServer from 'react-dom/server'
+import {
+  render,
+  fireEvent,
+  cleanup,
+  waitForElement,
+  wait
+} from 'react-testing-library'
+
+afterEach(cleanup)
+
+describe('<LazyTippy />', () => {
+  test('tooltip content is not rendered before show', () => {
+    class Content extends React.Component {
+      render() {
+        throw new Error('don`t need render')
+        return ''
+      }
+    }
+
+    render(
+      <LazyTippy content={<Content />}>
+        <button />
+      </LazyTippy>
+    )
+  })
+
+  test('tooltip content is rendered after trigger', async done => {
+    const Content = () => <span data-testid="content">Tooltip</span>
+
+    const onShow = jest.fn()
+    const onHidden = jest.fn()
+
+    const { container, getByTestId } = render(
+      <LazyTippy
+        duration={[0, 0]}
+        trigger="click"
+        onHidden={onHidden}
+        onShow={onShow}
+        content={<Content />}
+      >
+        <button />
+      </LazyTippy>
+    )
+
+    const button = container.querySelector('button')
+    const tip = button._tippy
+    fireEvent.click(button)
+    await waitForElement(() => getByTestId('content'))
+    fireEvent.click(button)
+
+    expect(onShow).toBeCalledTimes(1)
+    expect(onShow).toBeCalledWith(tip)
+    await wait(() => [
+      expect(onHidden).toBeCalledTimes(1),
+      expect(onHidden).toBeCalledWith(tip)
+    ])
+    done()
+  })
+
+  test('tooltip content is rendered after trigger without callbacks', async done => {
+    const Content = () => <span data-testid="content">Tooltip</span>
+
+    const { container, getByTestId } = render(
+      <LazyTippy duration={[0, 0]} trigger="click" content={<Content />}>
+        <button />
+      </LazyTippy>
+    )
+
+    const button = container.querySelector('button')
+    const tip = button._tippy
+    fireEvent.click(button)
+    await waitForElement(() => getByTestId('content'))
+    fireEvent.click(button)
+    done()
+  })
+})

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -1,13 +1,7 @@
 import React from 'react'
-import Tippy from '../src/Tippy'
+import Tippy from '../src'
 import ReactDOMServer from 'react-dom/server'
-import {
-  render,
-  fireEvent,
-  cleanup,
-  waitForElement,
-  wait
-} from 'react-testing-library'
+import { render, fireEvent, cleanup } from 'react-testing-library'
 
 afterEach(cleanup)
 
@@ -115,72 +109,6 @@ describe('<Tippy />', () => {
         </Tippy>
       ).includes('<div>Tooltip</div>')
     ).toBe(false)
-  })
-
-  test('tooltip content is not rendered before show when lazyRender', () => {
-    class Content extends React.Component {
-      render() {
-        throw new Error('don`t need render')
-        return ''
-      }
-    }
-
-    render(
-      <Tippy content={<Content />} lazyRender>
-        <button />
-      </Tippy>
-    )
-  })
-
-  test('tooltip content is rendered after trigger when lazyRender', async done => {
-    const Content = () => <span data-testid="content">Tooltip</span>
-
-    const onShow = jest.fn()
-    const onHidden = jest.fn()
-
-    const { container, getByTestId } = render(
-      <Tippy
-        duration={[0, 0]}
-        trigger="click"
-        onHidden={onHidden}
-        onShow={onShow}
-        content={<Content />}
-        lazyRender
-      >
-        <button />
-      </Tippy>
-    )
-
-    const button = container.querySelector('button')
-    const tip = button._tippy
-    fireEvent.click(button)
-    await waitForElement(() => getByTestId('content'))
-    fireEvent.click(button)
-
-    expect(onShow).toBeCalledTimes(1)
-    expect(onShow).toBeCalledWith(tip)
-    await wait(() => [
-      expect(onHidden).toBeCalledTimes(1),
-      expect(onHidden).toBeCalledWith(tip)
-    ])
-    done()
-  })
-
-  test('tooltip content is rendered after trigger when lazyRender without callbacks', async done => {
-    const Content = () => <span data-testid="content">Tooltip</span>
-
-    const { container, getByTestId } = render(
-      <Tippy duration={[0, 0]} trigger="click" content={<Content />} lazyRender>
-        <button />
-      </Tippy>
-    )
-
-    const button = container.querySelector('button')
-    const tip = button._tippy
-    fireEvent.click(button)
-    await waitForElement(() => getByTestId('content'))
-    fireEvent.click(button)
-    done()
   })
 
   test('props.isEnabled initially `true`', done => {

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -6,7 +6,7 @@ import {
   fireEvent,
   cleanup,
   waitForElement,
-  wait,
+  wait
 } from 'react-testing-library'
 
 afterEach(cleanup)

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -159,7 +159,10 @@ describe('<Tippy />', () => {
 
     expect(onShow).toBeCalledTimes(1)
     expect(onShow).toBeCalledWith(tip)
-    await wait(() => expect(onHidden).toBeCalledTimes(1))
+    await wait(() => [
+      expect(onHidden).toBeCalledTimes(1),
+      expect(onHidden).toBeCalledWith(tip)
+    ])
     done()
   })
 

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -1,7 +1,13 @@
 import React from 'react'
 import Tippy from '../src/Tippy'
 import ReactDOMServer from 'react-dom/server'
-import { render, fireEvent, cleanup } from 'react-testing-library'
+import {
+  render,
+  fireEvent,
+  cleanup,
+  waitForElement,
+  wait,
+} from 'react-testing-library'
 
 afterEach(cleanup)
 
@@ -109,6 +115,69 @@ describe('<Tippy />', () => {
         </Tippy>
       ).includes('<div>Tooltip</div>')
     ).toBe(false)
+  })
+
+  test('tooltip content is not rendered before show when lazyRender', () => {
+    class Content extends React.Component {
+      render() {
+        throw new Error('don`t need render')
+        return ''
+      }
+    }
+
+    render(
+      <Tippy content={<Content />} lazyRender>
+        <button />
+      </Tippy>
+    )
+  })
+
+  test('tooltip content is rendered after trigger when lazyRender', async done => {
+    const Content = () => <span data-testid="content">Tooltip</span>
+
+    const onShow = jest.fn()
+    const onHidden = jest.fn()
+
+    const { container, getByTestId } = render(
+      <Tippy
+        duration={[0, 0]}
+        trigger="click"
+        onHidden={onHidden}
+        onShow={onShow}
+        content={<Content />}
+        lazyRender
+      >
+        <button />
+      </Tippy>
+    )
+
+    const button = container.querySelector('button')
+    const tip = button._tippy
+    fireEvent.click(button)
+    await waitForElement(() => getByTestId('content'))
+    fireEvent.click(button)
+
+    expect(onShow).toBeCalledTimes(1)
+    expect(onShow).toBeCalledWith(tip)
+    await wait(() => expect(onHidden).toBeCalledTimes(1))
+    done()
+  })
+
+  test('tooltip content is rendered after trigger when lazyRender without callbacks', async done => {
+    const Content = () => <span data-testid="content">Tooltip</span>
+
+    const { container, getByTestId } = render(
+      <Tippy duration={[0, 0]} trigger="click" content={<Content />} lazyRender>
+        <button />
+      </Tippy>
+    )
+
+    const button = container.querySelector('button')
+    const tip = button._tippy
+    fireEvent.click(button)
+    await waitForElement(() => getByTestId('content'))
+    fireEvent.click(button)
+    done()
   })
 
   test('props.isEnabled initially `true`', done => {


### PR DESCRIPTION
Like in react-modal (https://github.com/reactjs/react-modal/blob/master/src/components/ModalPortal.js#L335) added the flag to render content inside tooltip after a show. It is needed, when content some hard - in my case datetimepicker. I think this is not needed for default, because of tooltips commonly light components.