### PR TITLE
V2 (WIP)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,8 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "presets": ["@babel/env", "@babel/react"],
   "plugins": [
-    "@babel/plugin-proposal-class-properties"
+    ["@babel/transform-destructuring", { "loose": true }, "unique"],
+    ["@babel/proposal-class-properties", { "loose": true }, "unique"],
+    ["@babel/proposal-object-rest-spread", { "loose": true }, "unique"]
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 coverage
 .devserver
 dist
+umd
+esm

--- a/README.md
+++ b/README.md
@@ -145,10 +145,9 @@ default props. From this file, you can import the component throughout your app.
 ```js
 import Tippy from '@tippy.js/react'
 
-// Disables data-tippy-* attributes as they are unnecessary in React
-// and slow down initialization.
 Tippy.defaultProps = {
-  ignoreAttributes: true,
+  ...Tippy.defaultProps,
+  arrow: true,
 }
 
 export default Tippy

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm i @tippy.js/react
 
 CDN: https://unpkg.com/@tippy.js/react
 
-Requires React 16.2+, `prop-types`, and `tippy.js` if using via CDN.
+Requires React 16.8+, `prop-types`, and `tippy.js` if using via CDN.
 
 ## Usage
 
@@ -53,7 +53,7 @@ ReactDOM.render(<App />, document.getElementById('root'))
 
 ## Native props
 
-See the [Tippy.js docs](https://atomiks.github.io/tippyjs/all-options)
+See the [Tippy.js docs](https://atomiks.github.io/tippyjs/all-options/)
 
 ## React-specific props
 
@@ -63,18 +63,13 @@ Prop to control the `tippy.enable()` / `tippy.disable()` instance methods. Use
 this when you want to temporarily disable a tippy from showing.
 
 ```jsx
-class App extends Component {
-  state = {
-    isEnabled: true,
-  }
-
-  render() {
-    return (
-      <Tippy content="test" isEnabled={this.state.isEnabled}>
-        <button />
-      </Tippy>
-    )
-  }
+function App() {
+  const [isEnabled, setIsEnabled] = useState(true)
+  return (
+    <Tippy content="test" isEnabled={isEnabled}>
+      <button />
+    </Tippy>
+  )
 }
 ```
 
@@ -85,18 +80,13 @@ when you want to programmatically show or hide the tippy instead of relying on
 UI events.
 
 ```jsx
-class App extends Component {
-  state = {
-    isVisible: true,
-  }
-
-  render() {
-    return (
-      <Tippy content="test" isVisible={this.state.isVisible}>
-        <button />
-      </Tippy>
-    )
-  }
+function App() {
+  const [isVisible, setIsVisible] = useState(true)
+  return (
+    <Tippy content="test" isVisible={isVisible}>
+      <button />
+    </Tippy>
+  )
 }
 ```
 
@@ -112,18 +102,38 @@ Callback invoked when the Tippy instance has been created. Use this when you
 need to store the Tippy instance on the component.
 
 ```jsx
-class App extends Component {
-  storeTippyInstance = tip => {
-    this.tip = tip
-  }
+function App() {
+  const tippyInstance = useRef()
+  return (
+    <Tippy
+      content="test"
+      onCreate={instance => (tippyInstance.current = instance)}
+    >
+      <button />
+    </Tippy>
+  )
+}
+```
 
-  render() {
-    return (
-      <Tippy content="test" onCreate={this.storeTippyInstance}>
+## <TippyGroup />
+
+Wraps the [`tippy.group()`](https://atomiks.github.io/tippyjs/misc/#groups)
+method.
+
+```jsx
+import { TippyGroup } from '@tippy.js/react'
+
+function App() {
+  return (
+    <TippyGroup delay={1000}>
+      <Tippy content="a">
         <button />
       </Tippy>
-    )
-  }
+      <Tippy content="b">
+        <button />
+      </Tippy>
+    </TippyGroup>
+  )
 }
 ```
 
@@ -135,10 +145,10 @@ default props. From this file, you can import the component throughout your app.
 ```js
 import Tippy from '@tippy.js/react'
 
-// `performance: true` disables data-tippy-* attributes as they are unnecessary
-// in React and slow down initialization.
+// Disables data-tippy-* attributes as they are unnecessary in React
+// and slow down initialization.
 Tippy.defaultProps = {
-  performance: true,
+  ignoreAttributes: true,
 }
 
 export default Tippy

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Wraps the [`tippy.group()`](https://atomiks.github.io/tippyjs/misc/#groups)
 method.
 
 ```jsx
-import { TippyGroup } from '@tippy.js/react'
+import Tippy, { TippyGroup } from '@tippy.js/react'
 
 function App() {
   return (

--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ function App() {
 }
 ```
 
+## Multiple tippys on a single reference
+
+You can nest the components, ensuring they have a `multiple` prop:
+
+```jsx
+<Tippy placement="bottom" multiple>
+  <Tippy placement="left" multiple>
+    <Tippy placement="right" multiple>
+      <Tippy multiple>
+        <button />
+      </Tippy>
+    </Tippy>
+  </Tippy>
+</Tippy>
+```
+
 ## `<TippyGroup />`
 
 Wraps the [`tippy.group()`](https://atomiks.github.io/tippyjs/misc/#groups)

--- a/README.md
+++ b/README.md
@@ -14,16 +14,13 @@ Requires React 16.2+, `prop-types`, and `tippy.js` if using via CDN.
 
 ## Usage
 
-Import the Tippy component and Tippy's CSS.
-
-Required: tooltip content as `props.content` and a single element child
+Required props: tooltip content as `props.content` and a single element child
 (reference) as `props.children`.
 
 ```jsx
 import React from 'react'
 import ReactDOM from 'react-dom'
 import Tippy from '@tippy.js/react'
-import 'tippy.js/dist/tippy.css'
 
 const RegularTooltip = () => (
   <Tippy content="Hello">
@@ -87,8 +84,6 @@ Prop to control the `tippy.show()` / `tippy.hide()` instance methods. Use this
 when you want to programmatically show or hide the tippy instead of relying on
 UI events.
 
-⚠️ **It must be accompanied by a `"manual"` trigger prop.**
-
 ```jsx
 class App extends Component {
   state = {
@@ -97,7 +92,7 @@ class App extends Component {
 
   render() {
     return (
-      <Tippy content="test" trigger="manual" isVisible={this.state.isVisible}>
+      <Tippy content="test" isVisible={this.state.isVisible}>
         <button />
       </Tippy>
     )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @tippy.js/react
 
-React component for [Tippy.js](https://github.com/atomiks/tippyjs) 3.
+React component for [Tippy.js](https://github.com/atomiks/tippyjs) 4.
 
 ## Installation
 
@@ -115,7 +115,7 @@ function App() {
 }
 ```
 
-## <TippyGroup />
+## `<TippyGroup />`
 
 Wraps the [`tippy.group()`](https://atomiks.github.io/tippyjs/misc/#groups)
 method.

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Tippy from '../src/Tippy'
-import 'tippy.js/dist/tippy.css'
+import Tippy, { TippyGroup } from '../src/Tippy'
 import './index.css'
 
 Tippy.defaultProps = {
@@ -147,6 +146,16 @@ class App extends React.Component {
         <Tippy>
           <ComponentChild />
         </Tippy>
+
+        <h1>Group</h1>
+        <TippyGroup delay={1000}>
+          <Tippy>
+            <button>Text</button>
+          </Tippy>
+          <Tippy>
+            <button>Text</button>
+          </Tippy>
+        </TippyGroup>
       </main>
     )
   }

--- a/demo/index.js
+++ b/demo/index.js
@@ -156,6 +156,15 @@ class App extends React.Component {
             <button>Text</button>
           </Tippy>
         </TippyGroup>
+
+        <h1>Multiple</h1>
+        <Tippy placement="bottom" multiple>
+          <Tippy placement="left" multiple>
+            <Tippy>
+              <button>Text</button>
+            </Tippy>
+          </Tippy>
+        </Tippy>
       </main>
     )
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,4 +11,7 @@ export interface TippyProps extends Omit<Props, 'content'> {
   isEnabled?: boolean
 }
 
-export default class Tippy extends React.Component<TippyProps> {}
+export const TippyGroup: React.FunctionComponent<TippyProps>
+
+declare const Tippy: React.ForwardRefExoticComponent<TippyProps>
+export default Tippy

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Instance, Props } from 'tippy.js'
+import { Instance, Props, GroupOptions } from 'tippy.js'
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
@@ -11,7 +11,11 @@ export interface TippyProps extends Omit<Props, 'content'> {
   isEnabled?: boolean
 }
 
-export const TippyGroup: React.FunctionComponent<TippyProps>
-
 declare const Tippy: React.ForwardRefExoticComponent<TippyProps>
 export default Tippy
+
+export interface TippyGroupProps extends GroupOptions {
+  children: Array<React.ReactElement<any>>
+}
+
+export const TippyGroup: React.FunctionComponent<TippyGroupProps>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5025,8 +5025,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5050,15 +5049,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5075,22 +5072,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5221,8 +5215,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5236,7 +5229,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5253,7 +5245,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5262,15 +5253,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5291,7 +5280,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5380,8 +5368,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5395,7 +5382,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5491,8 +5477,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5534,7 +5519,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5556,7 +5540,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5605,15 +5588,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -13871,9 +13852,9 @@
       "dev": true
     },
     "tippy.js": {
-      "version": "4.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-4.0.0-alpha.0.tgz",
-      "integrity": "sha512-CM2/+ofS9Tj6VXa96OHOLFAZVXu3htACTIk9Hhbaio/55TLlhGwnNLnC8D+UMVBragBJ7v4c6TFMd1n360vGfQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-4.0.0.tgz",
+      "integrity": "sha512-dwITTI5rmvuZJ+vCtaP1nm9zg0CuDcJgYB0SQ9LqXBLGKujKf7Ygg6j5K+9y+h3V3Gy0a+UVjHWsXEBcgANydw==",
       "requires": {
         "popper.js": "^1.14.7"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1716,6 +1716,22 @@
       "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
       "dev": true
     },
+    "@types/prop-types": {
+      "version": "15.5.8",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.8.tgz",
+      "integrity": "sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.8.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.2.tgz",
+      "integrity": "sha512-6mcKsqlqkN9xADrwiUz2gm9Wg4iGnlVGciwBRYFQSMWG6MQjhOZ/AVnxn+6v8nslFgfYTV8fNdE6XwKu6va5PA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
     "@types/semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
@@ -3632,6 +3648,12 @@
         "cssom": "0.3.x"
       }
     },
+    "csstype": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
+      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -5003,7 +5025,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5027,13 +5050,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5050,19 +5075,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5193,7 +5221,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5207,6 +5236,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5223,6 +5253,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5231,13 +5262,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5258,6 +5291,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5346,7 +5380,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5360,6 +5395,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5455,7 +5491,8 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5497,6 +5534,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5518,6 +5556,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5566,13 +5605,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13991,6 +14032,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
+      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tippy.js/react",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1636,12 +1636,6 @@
         }
       }
     },
-    "@comandeer/babel-plugin-banner": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-2.0.2.tgz",
-      "integrity": "sha512-5/GMOcgqBy/+cMYfOTFhqrioolOP+g7ADjl4jo1nYONwVGvMpzKPdweuVaJsC/Ol2PH+GmwlF2WrNP3xjWoSiw==",
-      "dev": true
-    },
     "@iamstarkov/listr-update-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",
@@ -1717,9 +1711,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w==",
+      "version": "10.12.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.21.tgz",
+      "integrity": "sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==",
       "dev": true
     },
     "@types/semver": {
@@ -1914,12 +1908,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -2151,48 +2139,6 @@
         "trim-right": "^1.0.1"
       }
     },
-    "babel-helper-evaluate-path": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.4.3.tgz",
-      "integrity": "sha1-ComvcCwGshcCf6NxkI3UmJ0+Yz8=",
-      "dev": true
-    },
-    "babel-helper-flip-expressions": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
-      "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0=",
-      "dev": true
-    },
-    "babel-helper-is-nodes-equiv": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
-      "dev": true
-    },
-    "babel-helper-is-void-0": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
-      "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4=",
-      "dev": true
-    },
-    "babel-helper-mark-eval-scopes": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
-      "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI=",
-      "dev": true
-    },
-    "babel-helper-remove-or-void": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
-      "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=",
-      "dev": true
-    },
-    "babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.4.3.tgz",
-      "integrity": "sha1-W1GLESf0ezA4dzOGoVYaK0jmMrY=",
-      "dev": true
-    },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
@@ -2240,177 +2186,10 @@
       "integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
       "dev": true
     },
-    "babel-plugin-minify-builtins": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.4.3.tgz",
-      "integrity": "sha1-nqPVn0rEp7uVjXEtKVVqH4b3+B4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.4.3"
-      }
-    },
-    "babel-plugin-minify-constant-folding": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.4.3.tgz",
-      "integrity": "sha1-MA+d6N2ghEoXaxk2U5YOJK0z4ZE=",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.4.3"
-      }
-    },
-    "babel-plugin-minify-dead-code-elimination": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.4.3.tgz",
-      "integrity": "sha1-c2KCZYZPkAjQAnUG9Yq+s8HQLZg=",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.4.3",
-        "babel-helper-mark-eval-scopes": "^0.4.3",
-        "babel-helper-remove-or-void": "^0.4.3",
-        "lodash.some": "^4.6.0"
-      }
-    },
-    "babel-plugin-minify-flip-comparisons": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
-      "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-is-void-0": "^0.4.3"
-      }
-    },
-    "babel-plugin-minify-guarded-expressions": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.3.tgz",
-      "integrity": "sha1-zHCbRFP9IbHzAod0RMifiEJ845c=",
-      "dev": true,
-      "requires": {
-        "babel-helper-flip-expressions": "^0.4.3"
-      }
-    },
-    "babel-plugin-minify-infinity": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
-      "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco=",
-      "dev": true
-    },
-    "babel-plugin-minify-mangle-names": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.4.3.tgz",
-      "integrity": "sha1-FvG/90t6fJPfwkHngx3V+0sCPvc=",
-      "dev": true,
-      "requires": {
-        "babel-helper-mark-eval-scopes": "^0.4.3"
-      }
-    },
-    "babel-plugin-minify-numeric-literals": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
-      "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw=",
-      "dev": true
-    },
-    "babel-plugin-minify-replace": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.4.3.tgz",
-      "integrity": "sha1-nSifS6FdTmAR6HmfpfG6d+yBIZ0=",
-      "dev": true
-    },
-    "babel-plugin-minify-simplify": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.4.3.tgz",
-      "integrity": "sha1-N3VthcYURktLCSfytOQXGR1Vc4o=",
-      "dev": true,
-      "requires": {
-        "babel-helper-flip-expressions": "^0.4.3",
-        "babel-helper-is-nodes-equiv": "^0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "^0.4.3"
-      }
-    },
-    "babel-plugin-minify-type-constructors": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
-      "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
-      "dev": true,
-      "requires": {
-        "babel-helper-is-void-0": "^0.4.3"
-      }
-    },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
-      "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE=",
-      "dev": true
-    },
-    "babel-plugin-transform-member-expression-literals": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
-      "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
-      "dev": true
-    },
-    "babel-plugin-transform-merge-sibling-variables": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
-      "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
-      "dev": true
-    },
-    "babel-plugin-transform-minify-booleans": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
-      "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
-      "dev": true
-    },
-    "babel-plugin-transform-property-literals": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
-      "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
-      "dev": true,
-      "requires": {
-        "esutils": "^2.0.2"
-      }
-    },
-    "babel-plugin-transform-regexp-constructors": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
-      "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU=",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-console": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
-      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-debugger": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
-      "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-undefined": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.4.3.tgz",
-      "integrity": "sha1-1AsNp/kcCMBsxyt2dHTAHEiU3gI=",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "^0.4.3"
-      }
-    },
-    "babel-plugin-transform-simplify-comparison-operators": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
-      "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
-      "dev": true
-    },
-    "babel-plugin-transform-undefined-to-void": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
-      "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
       "dev": true
     },
     "babel-preset-jest": {
@@ -2421,37 +2200,6 @@
       "requires": {
         "babel-plugin-jest-hoist": "^23.2.0",
         "babel-plugin-syntax-object-rest-spread": "^6.13.0"
-      }
-    },
-    "babel-preset-minify": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.3.tgz",
-      "integrity": "sha1-spw91pGJBThFmPCSuVUVLiah/g8=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-minify-builtins": "^0.4.3",
-        "babel-plugin-minify-constant-folding": "^0.4.3",
-        "babel-plugin-minify-dead-code-elimination": "^0.4.3",
-        "babel-plugin-minify-flip-comparisons": "^0.4.3",
-        "babel-plugin-minify-guarded-expressions": "^0.4.3",
-        "babel-plugin-minify-infinity": "^0.4.3",
-        "babel-plugin-minify-mangle-names": "^0.4.3",
-        "babel-plugin-minify-numeric-literals": "^0.4.3",
-        "babel-plugin-minify-replace": "^0.4.3",
-        "babel-plugin-minify-simplify": "^0.4.3",
-        "babel-plugin-minify-type-constructors": "^0.4.3",
-        "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
-        "babel-plugin-transform-member-expression-literals": "^6.9.4",
-        "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
-        "babel-plugin-transform-minify-booleans": "^6.9.4",
-        "babel-plugin-transform-property-literals": "^6.9.4",
-        "babel-plugin-transform-regexp-constructors": "^0.4.3",
-        "babel-plugin-transform-remove-console": "^6.9.4",
-        "babel-plugin-transform-remove-debugger": "^6.9.4",
-        "babel-plugin-transform-remove-undefined": "^0.4.3",
-        "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
-        "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "lodash.isplainobject": "^4.0.6"
       }
     },
     "babel-register": {
@@ -3409,12 +3157,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4170,14 +3912,57 @@
       }
     },
     "dom-testing-library": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/dom-testing-library/-/dom-testing-library-3.12.3.tgz",
-      "integrity": "sha512-HvoxiKm8s4Gf+T52MX+gYHKXkGBM4ZiKYElIZxt8zPZtbT3wokrjKHskzryRqRD3oAKeg6chtUe3gchrurhmvA==",
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/dom-testing-library/-/dom-testing-library-3.16.5.tgz",
+      "integrity": "sha512-t3OaTcDdsAqtAZNeZ13KnOJmt+2HaDJqYWyf0iBRzbG6GwrNtpF0122Ygu/qkerIwcnHMX1ihwZVx/DhaLpmTw==",
       "dev": true,
       "requires": {
+        "@babel/runtime": "^7.1.5",
         "@sheerun/mutationobserver-shim": "^0.3.2",
-        "pretty-format": "^23.6.0",
-        "wait-for-expect": "^1.0.0"
+        "pretty-format": "^24.0.0",
+        "wait-for-expect": "^1.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "pretty-format": {
+          "version": "24.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",
+          "integrity": "sha512-LszZaKG665djUcqg5ZQq+XzezHLKrxsA86ZABTozp+oNhkdqa+tG2dX4qa6ERl5c/sRDrAa3lHmwnvKoP+OG/g==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        }
       }
     },
     "domain-browser": {
@@ -4326,15 +4111,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -5047,21 +4823,6 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
       }
     },
     "figures": {
@@ -6770,15 +6531,6 @@
         }
       }
     },
-    "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
@@ -7327,16 +7079,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -8596,6 +8338,27 @@
         }
       }
     },
+    "jest-worker": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.0.0.tgz",
+      "integrity": "sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^1.0.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
@@ -9070,22 +8833,10 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
-    "lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
       "dev": true
     },
     "lodash.sortby": {
@@ -9468,16 +9219,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
     },
     "node-forge": {
       "version": "0.7.6",
@@ -10351,9 +10092,9 @@
       "dev": true
     },
     "popper.js": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.5.tgz",
-      "integrity": "sha512-fs4Sd8bZLgEzrk8aS7Em1qh+wcawtE87kRUJQhK6+LndyV1HerX7+LURzAylVaTyWIn5NTB/lyjnWqw/AZ6Yrw=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -12372,15 +12113,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "prop-types": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
@@ -12535,36 +12267,54 @@
       "dev": true
     },
     "react": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
-      "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.1.tgz",
+      "integrity": "sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.1"
       }
     },
     "react-dom": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
-      "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.1.tgz",
+      "integrity": "sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.1"
       }
     },
     "react-testing-library": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-5.2.3.tgz",
-      "integrity": "sha512-Bw52++7uORuIQnL55lK/WQfppqAc9+8yFG4lWUp/kmSOvYDnt8J9oI5fNCfAGSQi9iIhAv9aNsI2G5rtid0nrA==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-5.5.3.tgz",
+      "integrity": "sha512-67jMsSJHbbm9M0NWvEzjNikDAKRdxivhP6vnpa9xPg/fYh19zkE4rMsFh5YWLpyoomm+e49fg+ubcXaEBYartA==",
       "dev": true,
       "requires": {
-        "dom-testing-library": "^3.12.0"
+        "@babel/runtime": "^7.3.1",
+        "dom-testing-library": "^3.13.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
@@ -12880,91 +12630,106 @@
       }
     },
     "rollup": {
-      "version": "0.64.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.64.1.tgz",
-      "integrity": "sha512-+ThdVXrvonJdOTzyybMBipP0uz605Z8AnzWVY3rf+cSGnLO7uNkJBlN+9jXqWOomkvumXfm/esmBpA5d53qm7g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.1.2.tgz",
+      "integrity": "sha512-OkdMxqMl8pWoQc5D8y1cIinYQPPLV8ZkfLgCzL6SytXeNA2P7UHynEQXI9tYxuAjAMsSyvRaWnyJDLHMxq0XAg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*"
+        "@types/node": "*",
+        "acorn": "^6.0.5"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.0.7",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.7.tgz",
+          "integrity": "sha512-HNJNgE60C9eOTgn974Tlp3dpLZdUr+SoxxDwPaY9J/kDNOLQTkaDgwBUXAF4SSsrAwD9RpdxuHK/EbuF+W9Ahw==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-babel": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.0.3.tgz",
-      "integrity": "sha512-/PP0MgbPQyRywI4zRIJim6ySjTcOLo4kQbEbROqp9kOR3kHC3FeU++QpBDZhS2BcHtJTVZMVbBV46flbBN5zxQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz",
+      "integrity": "sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "rollup-pluginutils": "^2.3.0"
       }
     },
-    "rollup-plugin-babel-minify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel-minify/-/rollup-plugin-babel-minify-5.0.0.tgz",
-      "integrity": "sha512-/XMozvFf1wm0O04FEybfEGl05jq9RQ408Xx/GjCfCau9ETzKYlEkfdi19pj2EvmpbSO/r0yspMKmwnUHNycdsw==",
+    "rollup-plugin-node-resolve": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.0.tgz",
+      "integrity": "sha512-7Ni+/M5RPSUBfUaP9alwYQiIKnKeXCOHiqBpKUl9kwp3jX5ZJtgXAait1cne6pGEVUUztPD6skIKH9Kq9sNtfw==",
       "dev": true,
       "requires": {
-        "@comandeer/babel-plugin-banner": "^2.0.2",
-        "babel-core": "^6.26.0",
-        "babel-preset-minify": "^0.4.0",
-        "magic-string": "^0.24.0"
+        "builtin-modules": "^3.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.8.1"
       },
       "dependencies": {
-        "babel-core": {
-          "version": "6.26.3",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
-          }
+        "builtin-modules": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+          "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
+          "dev": true
         },
-        "magic-string": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.24.1.tgz",
-          "integrity": "sha512-YBfNxbJiixMzxW40XqJEIldzHyh5f7CZKalo1uZffevyrPEX8Qgo9s0dmcORLHdV47UyvJg8/zD+6hQG3qvJrA==",
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "dev": true,
           "requires": {
-            "sourcemap-codec": "^1.4.1"
+            "path-parse": "^1.0.6"
           }
         }
       }
     },
-    "rollup-plugin-node-resolve": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz",
-      "integrity": "sha512-PJcd85dxfSBWih84ozRtBkB731OjXk0KnzN0oGp7WOWcarAFkVa71cV5hTJg2qpVsV2U8EUwrzHP3tvy9vS3qg==",
+    "rollup-plugin-terser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
+      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^2.0.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.1.6"
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^24.0.0",
+        "serialize-javascript": "^1.6.1",
+        "terser": "^3.14.1"
       },
       "dependencies": {
-        "builtin-modules": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
-          "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+          "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "terser": {
+          "version": "3.16.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-3.16.1.tgz",
+          "integrity": "sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==",
+          "dev": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.9"
+          }
         }
       }
     },
@@ -13145,6 +12910,16 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "scheduler": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.1.tgz",
+      "integrity": "sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -13177,6 +12952,12 @@
         "range-parser": "~1.2.0",
         "statuses": "~1.4.0"
       }
+    },
+    "serialize-javascript": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
+      "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
+      "dev": true
     },
     "serialize-to-js": {
       "version": "1.2.1",
@@ -13521,12 +13302,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
-    },
-    "sourcemap-codec": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz",
-      "integrity": "sha512-hX1eNBNuilj8yfFnECh0DzLgwKpBLMIvmhgEhixXNui8lMLBInTI8Kyxt++RwJnMNu7cAUo635L2+N1TxMJCzA==",
       "dev": true
     },
     "spdx-correct": {
@@ -14055,11 +13830,11 @@
       "dev": true
     },
     "tippy.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-3.2.0.tgz",
-      "integrity": "sha512-OBZzx/g0ukTJ4CpS165pNU8RZ1uSWG1rDJHLFol4nA8kt+8VB7DQbnXh/HFEJ2hxo7K3+Np3Acqn0NbJ6iJUIg==",
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-CM2/+ofS9Tj6VXa96OHOLFAZVXu3htACTIk9Hhbaio/55TLlhGwnNLnC8D+UMVBragBJ7v4c6TFMd1n360vGfQ==",
       "requires": {
-        "popper.js": "^1.14.5"
+        "popper.js": "^1.14.7"
       }
     },
     "tmp": {
@@ -14216,12 +13991,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "ua-parser-js": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
       "dev": true
     },
     "uglify-js": {
@@ -14516,9 +14285,9 @@
       }
     },
     "wait-for-expect": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.0.1.tgz",
-      "integrity": "sha512-TPZMSxGWUl2DWmqdspLDEy97/S1Mqq0pzbh2A7jTq0WbJurUb5GKli+bai6ayeYdeWTF0rQNWZmUvCVZ9gkrfA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.1.0.tgz",
+      "integrity": "sha512-vQDokqxyMyknfX3luCDn16bSaRcOyH6gGuUXMIbxBLeTo6nWuEWYqMTT9a+44FmW8c2m6TRWBdNvBBjA1hwEKg==",
       "dev": true
     },
     "walker": {
@@ -14582,12 +14351,6 @@
           }
         }
       }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@tippy.js/react",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "React component for Tippy.js",
-  "main": "dist/Tippy.js",
-  "module": "dist/esm/Tippy.js",
+  "main": "./umd/index.min.js",
+  "module": "./esm/index.js",
   "types": "index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "dev": "parcel demo/index.html -d .devserver --no-cache --open",
     "build": "node rollup.build.js",
@@ -41,7 +42,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.2",
-    "tippy.js": "^3.2.0"
+    "tippy.js": "^4.0.0-alpha.0"
   },
   "peerDependencies": {
     "react": ">=16.2",
@@ -64,13 +65,13 @@
     "lint-staged": "^8.1.0",
     "parcel": "^1.10.3",
     "prettier": "^1.16.1",
-    "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "react-testing-library": "^5.2.3",
-    "rollup": "^0.64.1",
-    "rollup-plugin-babel": "^4.0.3",
-    "rollup-plugin-babel-minify": "^5.0.0",
-    "rollup-plugin-node-resolve": "^3.4.0"
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
+    "react-testing-library": "^5.5.3",
+    "rollup": "^1.1.2",
+    "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-node-resolve": "^4.0.0",
+    "rollup-plugin-terser": "^4.0.4"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.2",
-    "tippy.js": "^4.0.0-alpha.0"
+    "tippy.js": "^4.0.0"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "tippy.js": "^4.0.0-alpha.0"
   },
   "peerDependencies": {
-    "react": ">=16.2",
-    "react-dom": ">=16.2"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
+    "@types/react": "^16.8.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
@@ -71,7 +72,8 @@
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-node-resolve": "^4.0.0",
-    "rollup-plugin-terser": "^4.0.4"
+    "rollup-plugin-terser": "^4.0.4",
+    "typescript": "^3.3.3"
   },
   "directories": {
     "test": "test"

--- a/rollup.build.js
+++ b/rollup.build.js
@@ -1,18 +1,10 @@
 const { rollup } = require('rollup')
 const babel = require('rollup-plugin-babel')
-const minify = require('rollup-plugin-babel-minify')
+const { terser } = require('rollup-plugin-terser')
 const resolve = require('rollup-plugin-node-resolve')
 
-const pluginBabel = babel({
-  babelrc: false,
-  exclude: 'node_modules/**',
-  presets: ['@babel/preset-env', '@babel/preset-react'],
-  plugins: [
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
-  ],
-})
-const pluginMinify = minify({ comments: false })
+const pluginBabel = babel({ exclude: 'node_modules/**' })
+const pluginMinify = terser()
 const pluginResolve = resolve()
 
 const rollupConfig = (...plugins) => ({
@@ -32,6 +24,7 @@ const output = format => file => ({
     'react-dom': 'ReactDOM',
     'prop-types': 'PropTypes',
   },
+  exports: 'named',
 })
 
 const umd = output('umd')
@@ -41,10 +34,10 @@ const build = async () => {
   const bundle = await rollup(rollupConfig())
   const bundleMin = await rollup(rollupConfig(pluginMinify))
 
-  bundle.write(umd('./dist/Tippy.js'))
-  bundleMin.write(umd('./dist/Tippy.min.js'))
-  bundle.write(esm('./dist/esm/Tippy.js'))
-  bundleMin.write(esm('./dist/esm/Tippy.min.js'))
+  bundle.write(umd('./umd/index.js'))
+  bundleMin.write(umd('./umd/index.min.js'))
+  bundle.write(esm('./esm/index.js'))
+  bundleMin.write(esm('./esm/index.min.js'))
 }
 
 build()

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -97,6 +97,10 @@ Tippy.propTypes = {
   isEnabled: PropTypes.bool,
 }
 
+Tippy.defaultProps = {
+  ignoreAttributes: true,
+}
+
 export default React.forwardRef(function TippyWrapper(props, ref) {
   return (
     <Tippy {...props}>

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -77,14 +77,12 @@ function Tippy(props) {
 
   return (
     <>
-      {React.Children.map(props.children, child =>
-        React.cloneElement(child, {
-          ref: node => {
-            reference.current = node
-            preserveRef(child, node)
-          },
-        }),
-      )}
+      {React.cloneElement(props.children, {
+        ref: node => {
+          reference.current = node
+          preserveRef(props.children.ref, node)
+        },
+      })}
       {isMounted && ReactDOM.createPortal(props.content, container.current)}
     </>
   )
@@ -99,5 +97,17 @@ Tippy.propTypes = {
   isEnabled: PropTypes.bool,
 }
 
-export default Tippy
+export default React.forwardRef(function TippyWrapper(props, ref) {
+  return (
+    <Tippy {...props}>
+      {React.cloneElement(props.children, {
+        ref: node => {
+          preserveRef(ref, node)
+          preserveRef(props.children.ref, node)
+        },
+      })}
+    </Tippy>
+  )
+})
+
 export { TippyGroup }

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -2,106 +2,102 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import tippy from 'tippy.js'
+import {
+  getNativeTippyProps,
+  hasOwnProperty,
+  ssrSafeCreateDiv,
+  preserveRef,
+} from './utils'
 
-// These props are not native to `tippy.js` and are specific to React only.
-const REACT_ONLY_PROPS = ['children', 'onCreate', 'isVisible', 'isEnabled']
+import TippyGroup from './TippyGroup'
 
-// Avoid Babel's large '_objectWithoutProperties' helper function.
-function getNativeTippyProps(props) {
-  return Object.keys(props).reduce((acc, key) => {
-    if (REACT_ONLY_PROPS.indexOf(key) === -1) {
-      acc[key] = props[key]
-    }
-    return acc
-  }, {})
-}
+function Tippy(props) {
+  const [isMounted, setIsMounted] = React.useState(false)
+  const container = React.useRef(ssrSafeCreateDiv())
+  const reference = React.useRef()
+  const instance = React.useRef()
 
-class Tippy extends React.Component {
-  state = { isMounted: false }
-
-  container = typeof document !== 'undefined' && document.createElement('div')
-
-  static propTypes = {
-    content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
-      .isRequired,
-    children: PropTypes.element.isRequired,
-    onCreate: PropTypes.func,
-    isVisible: PropTypes.bool,
-    isEnabled: PropTypes.bool,
+  const options = {
+    ...getNativeTippyProps(props),
+    content: container.current,
   }
 
-  get isReactElementContent() {
-    return React.isValidElement(this.props.content)
+  if (hasOwnProperty(props, 'isVisible')) {
+    options.trigger = 'manual'
   }
 
-  get options() {
-    return {
-      ...getNativeTippyProps(this.props),
-      content: this.isReactElementContent ? this.container : this.props.content,
-    }
-  }
+  React.useEffect(() => {
+    instance.current = tippy(reference.current, options)
 
-  get isManualTrigger() {
-    return this.props.trigger === 'manual'
-  }
-
-  componentDidMount() {
-    this.setState({ isMounted: true })
-
-    this.tip = tippy.one(ReactDOM.findDOMNode(this), this.options)
-
-    const { onCreate, isEnabled, isVisible } = this.props
+    const { onCreate, isEnabled, isVisible } = props
 
     if (onCreate) {
-      onCreate(this.tip)
+      onCreate(instance.current)
     }
 
     if (isEnabled === false) {
-      this.tip.disable()
+      instance.current.disable()
     }
 
-    if (this.isManualTrigger && isVisible === true) {
-      this.tip.show()
+    if (isVisible === true) {
+      instance.current.show()
     }
-  }
 
-  componentDidUpdate() {
-    this.tip.set(this.options)
+    setIsMounted(true)
 
-    const { isEnabled, isVisible } = this.props
+    return () => {
+      instance.current.destroy()
+      instance.current = null
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (!isMounted) {
+      return
+    }
+
+    instance.current.set(options)
+
+    const { isEnabled, isVisible } = props
 
     if (isEnabled === true) {
-      this.tip.enable()
+      instance.current.enable()
     }
     if (isEnabled === false) {
-      this.tip.disable()
+      instance.current.disable()
     }
 
-    if (this.isManualTrigger) {
-      if (isVisible === true) {
-        this.tip.show()
-      }
-      if (isVisible === false) {
-        this.tip.hide()
-      }
+    if (isVisible === true) {
+      instance.current.show()
     }
-  }
+    if (isVisible === false) {
+      instance.current.hide()
+    }
+  })
 
-  componentWillUnmount() {
-    this.tip.destroy()
-    this.tip = null
-  }
+  return (
+    <>
+      {React.Children.map(props.children, child =>
+        React.cloneElement(child, {
+          ref: node => {
+            reference.current = node
+            preserveRef(child, node)
+          },
+        }),
+      )}
+      {isMounted && ReactDOM.createPortal(props.content, container.current)}
+    </>
+  )
+}
 
-  render() {
-    return (
-      <React.Fragment>
-        {this.props.children}
-        {this.isReactElementContent &&
-          this.state.isMounted &&
-          ReactDOM.createPortal(this.props.content, this.container)}
-      </React.Fragment>
-    )
-  }
+Tippy.propTypes = {
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+    .isRequired,
+  children: PropTypes.element.isRequired,
+  onCreate: PropTypes.func,
+  isVisible: PropTypes.bool,
+  isEnabled: PropTypes.bool,
 }
 
 export default Tippy
+export { TippyGroup }

--- a/src/TippyGroup.js
+++ b/src/TippyGroup.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import tippy from 'tippy.js'
+
+export default function TippyGroup({ children, ...props }) {
+  const instances = React.useRef([])
+
+  React.useEffect(() => {
+    tippy.group(instances.current, props)
+    return () => {
+      instances.current = null
+    }
+  }, [])
+
+  return React.Children.map(children, child => {
+    return React.cloneElement(child, {
+      onCreate: instance => {
+        if (child.props.onCreate) {
+          child.props.onCreate(instance)
+        }
+        instances.current.push(instance)
+      },
+    })
+  })
+}

--- a/src/TippyGroup.js
+++ b/src/TippyGroup.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import tippy from 'tippy.js'
 
 export default function TippyGroup({ children, ...props }) {
@@ -21,4 +22,8 @@ export default function TippyGroup({ children, ...props }) {
       },
     })
   })
+}
+
+TippyGroup.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,25 @@
+export function getNativeTippyProps(props) {
+  // eslint-disable-next-line no-unused-vars
+  const { children, onCreate, isVisible, isEnabled, ...nativeProps } = props
+  return nativeProps
+}
+
+export function hasOwnProperty(obj, key) {
+  return {}.hasOwnProperty.call(obj, key)
+}
+
+export function preserveRef(reactElement, node) {
+  const { ref } = reactElement
+  if (ref) {
+    if (typeof ref === 'function') {
+      ref(node)
+    }
+    if (hasOwnProperty(ref, 'current')) {
+      ref.current = node
+    }
+  }
+}
+
+export function ssrSafeCreateDiv() {
+  return typeof document !== 'undefined' && document.createElement('div')
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,8 +8,7 @@ export function hasOwnProperty(obj, key) {
   return {}.hasOwnProperty.call(obj, key)
 }
 
-export function preserveRef(reactElement, node) {
-  const { ref } = reactElement
+export function preserveRef(ref, node) {
   if (ref) {
     if (typeof ref === 'function') {
       ref(node)

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -140,6 +140,18 @@ describe('<Tippy />', () => {
     render(<App />)
   })
 
+  test('nesting', () => {
+    render(
+      <Tippy content="tooltip" placement="bottom" multiple>
+        <Tippy content="tooltip" placement="left" multiple>
+          <Tippy content="tooltip">
+            <button>Text</button>
+          </Tippy>
+        </Tippy>
+      </Tippy>,
+    )
+  })
+
   test('props.isEnabled initially `true`', done => {
     booleanPropsBoilerplate('isEnabled', true, done)
   })

--- a/test/TippyGroup.test.js
+++ b/test/TippyGroup.test.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import Tippy, { TippyGroup } from '../src/Tippy'
+import { render, cleanup } from 'react-testing-library'
+
+afterEach(cleanup)
+
+describe('<TippyGroup />', () => {
+  test('renders without crashing', () => {
+    render(
+      <TippyGroup>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+      </TippyGroup>,
+    )
+  })
+
+  test('indicates the instances have been grouped', done => {
+    function App() {
+      const ref = React.useRef()
+
+      React.useEffect(() => {
+        // _originalProps is added by tippy.group(), we're relying on it not
+        // changing in tippy.js implementation
+        expect(ref.current._tippy._originalProps).toBeDefined()
+        done()
+      }, [])
+
+      return (
+        <TippyGroup>
+          <Tippy content="tooltip">
+            <button ref={ref} />
+          </Tippy>
+          <Tippy content="tooltip">
+            <button />
+          </Tippy>
+        </TippyGroup>
+      )
+    }
+
+    render(<App />)
+  })
+
+  test('preserves onCreate() prop', done => {
+    function App() {
+      function onCreate(instance) {
+        expect(instance.popper).toBeDefined()
+        done()
+      }
+
+      return (
+        <TippyGroup>
+          <Tippy content="tooltip" onCreate={onCreate}>
+            <button />
+          </Tippy>
+          <Tippy content="tooltip">
+            <button />
+          </Tippy>
+        </TippyGroup>
+      )
+    }
+
+    render(<App />)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    // only used for typechecking
+    "compilerOptions": {
+        "moduleResolution": "node"
+    }
+}


### PR DESCRIPTION
Upgrading to `tippy.js@4` once it's released

Highlights:

- Using Hooks, smaller bundle
- No more `findDOMNode()`, now using `cloneElement` with a `ref`. Ok, I don't know why I didn't see this being viable before, or anyone else pointing it out 😆.  To wrap components, you'll need to use `forwardRef()`. Since `styled-components@4` uses this already it's pretty seamless for most use cases. 
- No need to specify `trigger="manual"`, it's added for you if `isVisible` is specified as a prop

Additional export(s):

- `tippy.group()` wrapper

```jsx
import { TippyGroup } from '@tippy.js/react'

// Usage:
<TippyGroup delay={1000}>
  <Tippy content="a">
    <button />
  </Tippy>
  <Tippy content="b">
    <button />
  </Tippy>
</TippyGroup>
```