### PR TITLE
Add popperClassName prop

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -26,6 +26,7 @@ function Tippy({
   children,
   content,
   className,
+  popperClassName,
   onCreate,
   isEnabled = true,
   isVisible,
@@ -100,6 +101,16 @@ function Tippy({
       }
     }
   }, [className])
+
+  useIsomorphicLayoutEffect(() => {
+    if (popperClassName) {
+      const { popper } = instanceRef.current
+      updateClassName(popper, 'add', popperClassName)
+      return () => {
+        updateClassName(popper, 'remove', popperClassName)
+      }
+    }
+  }, [popperClassName])
 
   return (
     <>

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -103,6 +103,57 @@ describe('<Tippy />', () => {
     expect(tooltip.classList.contains('two')).toBe(true)
   })
 
+  test('props.popperClassName: single name is added to tooltip', () => {
+    const popperClassName = 'hello'
+    const { container } = render(
+      <Tippy content="tooltip" popperClassName={popperClassName}>
+        <button />
+      </Tippy>,
+    )
+    const { popper } = container.querySelector('button')._tippy
+    expect(popper.classList.contains(popperClassName)).toBe(true)
+  })
+
+  test('props.popperClassName: multiple names are added to tooltip', () => {
+    const popperClassName = 'hello world'
+    const { container } = render(
+      <Tippy content="tooltip" popperClassName={popperClassName}>
+        <button />
+      </Tippy>,
+    )
+    const { popper } = container.querySelector('button')._tippy
+    expect(popper.classList.contains('hello')).toBe(true)
+    expect(popper.classList.contains('world')).toBe(true)
+  })
+
+  test('props.popperClassName: extra whitespace is ignored', () => {
+    const popperClassName = ' hello world  '
+    const { container } = render(
+      <Tippy content="tooltip" popperClassName={popperClassName}>
+        <button />
+      </Tippy>,
+    )
+    const { popper } = container.querySelector('button')._tippy
+    expect(popper.className).toBe('tippy-popper hello world')
+  })
+
+  test('props.popperClassName: updating does not leave stale popperClassName behind', () => {
+    const { container, rerender } = render(
+      <Tippy content="tooltip" popperClassName="one">
+        <button />
+      </Tippy>,
+    )
+    const { popper } = container.querySelector('button')._tippy
+    expect(popper.classList.contains('one')).toBe(true)
+    rerender(
+      <Tippy content="tooltip" popperClassName="two">
+        <button />
+      </Tippy>,
+    )
+    expect(popper.classList.contains('one')).toBe(false)
+    expect(popper.classList.contains('two')).toBe(true)
+  })
+
   test('unmount destroys the tippy instance and allows garbage collection', () => {
     const { container, unmount } = render(
       <Tippy content="tooltip">


### PR DESCRIPTION
cc @kubajastrz and @vstas

Just repeating the `className` tests, should I extract a generic test helper?

But:

- 🤔 Should I instead just bump the major and put `className` on the parent popper instead?
- 🤔 Should I bump `tippy.js` version and add `x-placement` to the tooltip node as well, preventing all this? (And making it cleaner to use themes in the underyling library too)

Use in SC:

```jsx
import Tippy from '@tippy.js/react'

const Tippy2 = ({ className, ...props }) => (
  <Tippy popperClassName={className} {...props} />
)

const PurpleTippy = styled(Tippy2)`
  .tippy-tooltip {
    background: purple;
  }
`
```