### PR TITLE
Remove need for explicit multiple prop

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -30,6 +30,7 @@ function Tippy({
   isVisible,
   isEnabled = true,
   ignoreAttributes = true,
+  multiple = true,
   ...nativeProps
 }) {
   const [isMounted, setIsMounted] = useState(false)
@@ -41,6 +42,7 @@ function Tippy({
   const options = {
     ...nativeProps,
     ignoreAttributes,
+    multiple,
     content: containerRef.current,
   }
 

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -31,7 +31,7 @@ function Tippy({
   isEnabled = true,
   ignoreAttributes = true,
   multiple = true,
-  ...nativeProps
+  ...restOfNativeProps
 }) {
   const [isMounted, setIsMounted] = useState(false)
   const containerRef = useRef(ssrSafeCreateDiv())
@@ -40,9 +40,9 @@ function Tippy({
   const isControlledMode = typeof isVisible === 'boolean'
 
   const options = {
-    ...nativeProps,
     ignoreAttributes,
     multiple,
+    ...restOfNativeProps,
     content: containerRef.current,
   }
 

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -168,14 +168,15 @@ describe('<Tippy />', () => {
 
   test('nesting', () => {
     render(
-      <Tippy content="tooltip" placement="bottom" multiple>
-        <Tippy content="tooltip" placement="left" multiple>
-          <Tippy content="tooltip">
+      <Tippy content="tooltip" placement="bottom" isVisible>
+        <Tippy content="tooltip" placement="left" isVisible>
+          <Tippy content="tooltip" isVisible>
             <button>Text</button>
           </Tippy>
         </Tippy>
       </Tippy>,
     )
+    expect(document.querySelectorAll('.tippy-popper').length).toBe(3)
   })
 
   test('props.isEnabled initially `true`', () => {


### PR DESCRIPTION
`multiple` can safely be true by default with this wrapper since React's rendering ensures `tippy()` only called once upon mounting, there will never be duplicate tooltips

It's safely backwards-compatible.

Also adds an assertion to the test.