### PR TITLE
Make <TippyGroup /> updateable

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "prop-types": "^15.6.2",
-    "tippy.js": "^4.2.1"
+    "tippy.js": "^4.3.0"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/src/TippyGroup.js
+++ b/src/TippyGroup.js
@@ -7,10 +7,7 @@ export default function TippyGroup({ children, ...props }) {
 
   useEffect(() => {
     tippy.group(instancesRef.current, props)
-    return () => {
-      instancesRef.current = null
-    }
-  }, [])
+  })
 
   return Children.map(children, child => {
     return cloneElement(child, {

--- a/test/TippyGroup.test.js
+++ b/test/TippyGroup.test.js
@@ -65,4 +65,32 @@ describe('<TippyGroup />', () => {
 
     render(<App />)
   })
+
+  test('props are updateable', () => {
+    const delay = 1000
+    const nextDelay = 500
+    const { container, rerender } = render(
+      <TippyGroup delay={delay}>
+        <Tippy content="toolip">
+          <button />
+        </Tippy>
+        <Tippy content="toolip">
+          <button />
+        </Tippy>
+      </TippyGroup>,
+    )
+    const instance = container.querySelector('button')._tippy
+    expect(instance.props.delay).toBe(delay)
+    rerender(
+      <TippyGroup delay={nextDelay}>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="toolip">
+          <button />
+        </Tippy>
+      </TippyGroup>,
+    )
+    expect(instance.props.delay).toBe(nextDelay)
+  })
 })


### PR DESCRIPTION
WIP, only to merge after `tippy.js@4.3.0` is released since that's when `group()` can be called multiple times to update its props.