### PR TITLE
disabling the tooltip will hide it if it is visible

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -91,6 +91,10 @@ function Tippy({
     if (enabled) {
       instanceRef.current.enable()
     } else {
+      if (!isControlledMode) {
+        instanceRef.current.hide()
+      }
+
       instanceRef.current.disable()
     }
 

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -306,4 +306,21 @@ describe('<Tippy />', () => {
     )
     expect(instance.state.isVisible).toBe(true)
   })
+
+  test('setting enabled to false hides the tooltip if it is visible', () => {
+    const { container, rerender } = render(
+      <Tippy content="tooltip" enabled={true}>
+        <button />
+      </Tippy>,
+    )
+    const instance = container.querySelector('button')._tippy
+    instance.show()
+    rerender(
+      <Tippy content="tooltip" enabled={false}>
+        <button />
+      </Tippy>,
+    )
+    expect(instance.state.isEnabled).toBe(false)
+    expect(instance.state.isVisible).toBe(false)
+  })
 })


### PR DESCRIPTION
Currently I don't believe there is a way to hide a tooltip which has been triggered by a hover event.

The scenario is:
- the tooltip is shown, triggered by a hover
- the user makes a change which means that the tooltip is no longer needed
- enabled is set to false
- the tooltip is still present and will never be hidden