### PR TITLE
Fix `content` and `children` props type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import { Instance, Options, GroupOptions } from 'tippy.js'
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
 export interface TippyProps extends Omit<Options, 'content'> {
-  content: React.ReactElement<any> | string
+  content: React.ReactChild | React.ReactChild[]
   children: React.ReactElement<any>
   onCreate?: (instance: Instance) => void
   /** @deprecated Use `visible` instead */

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -126,8 +126,13 @@ function Tippy({
   )
 }
 
+const ContentType = PropTypes.oneOfType([
+  PropTypes.number,
+  PropTypes.string,
+  PropTypes.element,
+])
 Tippy.propTypes = {
-  content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+  content: PropTypes.oneOf([ContentType, PropTypes.arrayOf(ContentType)])
     .isRequired,
   children: PropTypes.element.isRequired,
   onCreate: PropTypes.func,

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -126,21 +126,23 @@ function Tippy({
   )
 }
 
-const ContentType = PropTypes.oneOfType([
-  PropTypes.number,
-  PropTypes.string,
-  PropTypes.element,
-])
-Tippy.propTypes = {
-  content: PropTypes.oneOf([ContentType, PropTypes.arrayOf(ContentType)])
-    .isRequired,
-  children: PropTypes.element.isRequired,
-  onCreate: PropTypes.func,
-  isVisible: PropTypes.bool, // deprecated
-  isEnabled: PropTypes.bool, // deprecated
-  visible: PropTypes.bool,
-  enabled: PropTypes.bool,
-  className: PropTypes.string,
+if (process.env.NODE_ENV !== 'production') {
+  const ContentType = PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+    PropTypes.element,
+  ])
+  Tippy.propTypes = {
+    content: PropTypes.oneOf([ContentType, PropTypes.arrayOf(ContentType)])
+      .isRequired,
+    children: PropTypes.element.isRequired,
+    onCreate: PropTypes.func,
+    isVisible: PropTypes.bool, // deprecated
+    isEnabled: PropTypes.bool, // deprecated
+    visible: PropTypes.bool,
+    enabled: PropTypes.bool,
+    className: PropTypes.string,
+  }
 }
 
 export default forwardRef(function TippyWrapper({ children, ...props }, ref) {

--- a/src/TippyGroup.js
+++ b/src/TippyGroup.js
@@ -21,6 +21,8 @@ export default function TippyGroup({ children, ...props }) {
   })
 }
 
-TippyGroup.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+if (process.env.NODE_ENV !== 'production') {
+  TippyGroup.propTypes = {
+    children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  }
 }


### PR DESCRIPTION
Instead of limiting the elements to one string or one react element, would be better if it allows one (string, number, or react element) or an array of them.

Which, actually, it already works.