### PR TITLE
Re-export tippy core in typings file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Instance, Options, GroupOptions } from 'tippy.js'
+import { default as tippyCore, Instance, Options, GroupOptions } from 'tippy.js'
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
@@ -18,6 +18,8 @@ export interface TippyProps extends Omit<Options, 'content'> {
 
 declare const Tippy: React.ForwardRefExoticComponent<TippyProps>
 export default Tippy
+
+export const tippy: typeof tippyCore;
 
 export interface TippyGroupProps extends GroupOptions {
   children: Array<React.ReactElement<any>>


### PR DESCRIPTION
Missing types after d08169019f62382a9c6374b7eab99b3ce4193d7f