### PR TITLE
Account for children update

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -79,7 +79,7 @@ function Tippy({
       instanceRef.current.destroy()
       instanceRef.current = null
     }
-  }, [])
+  }, [children.type])
 
   useIsomorphicLayoutEffect(() => {
     if (!mounted) {

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -115,6 +115,11 @@ describe('<Tippy />', () => {
   })
 
   test('updating children destroys old instance and creates new one', () => {
+    const Button = (_, ref) => <button ref={ref} />
+    const Main = (_, ref) => <main ref={ref} />
+    const Component1 = React.forwardRef(Button)
+    const Component2 = React.forwardRef(Main)
+
     const { container, rerender } = render(
       <Tippy content="tooltip">
         <div />
@@ -126,8 +131,24 @@ describe('<Tippy />', () => {
         <span />
       </Tippy>,
     )
+    const span = container.querySelector('span')
     expect(div._tippy).toBeUndefined()
-    expect(container.querySelector('span')._tippy).toBeDefined()
+    expect(span._tippy).toBeDefined()
+    rerender(
+      <Tippy content="tooltip">
+        <Component1 />
+      </Tippy>,
+    )
+    const button = container.querySelector('button')
+    expect(span._tippy).toBeUndefined()
+    expect(button._tippy).toBeDefined()
+    rerender(
+      <Tippy content="tooltip">
+        <Component2 />
+      </Tippy>,
+    )
+    expect(button._tippy).toBeUndefined()
+    expect(container.querySelector('main')._tippy).toBeDefined()
   })
 
   test('updating props updates the tippy instance', () => {

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -114,6 +114,22 @@ describe('<Tippy />', () => {
     expect(button._tippy).toBeUndefined()
   })
 
+  test('updating children destroys old instance and creates new one', () => {
+    const { container, rerender } = render(
+      <Tippy content="tooltip">
+        <div />
+      </Tippy>,
+    )
+    const div = container.querySelector('div')
+    rerender(
+      <Tippy content="tooltip">
+        <span />
+      </Tippy>,
+    )
+    expect(div._tippy).toBeUndefined()
+    expect(container.querySelector('span')._tippy).toBeDefined()
+  })
+
   test('updating props updates the tippy instance', () => {
     const { container, rerender } = render(
       <Tippy content="tooltip" arrow={false}>


### PR DESCRIPTION
Mentioned a while ago in #51, especially with hot-reloading when changing the child tag type, there are problems. React remounts when the `children.type` changes (e.g. changing from `<span>` to `<div>`), which is when we need to create a new instance