### PR TITLE
Allow instance options to update on 2nd render and afterwards instead of 3rd

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -85,8 +85,8 @@ function Tippy({
   }, [children.type])
 
   useIsomorphicLayoutEffect(() => {
-    // Prevent this effect from running on 1st + 2nd render (setMounted())
-    if ($this.renders < 3) {
+    // Prevent this effect from running on 1st render
+    if ($this.renders === 1) {
       $this.renders++
       return
     }

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -167,6 +167,27 @@ describe('<Tippy />', () => {
     expect(instance.props.arrow).toBe(true)
   })
 
+  test('props containing refs updates the tippy instance on mount', () => {
+    const App = () => {
+      const [triggerTarget, setTriggerTarget] = React.useState(null)
+      return (
+        <div ref={el => setTriggerTarget(el)}>
+          Trigger Target
+          <Tippy content="tooltip" triggerTarget={triggerTarget}>
+            <button />
+          </Tippy>
+        </div>
+      )
+    }
+
+    const { container } = render(<App />)
+
+    const instanceNode = container.querySelector('button')
+    const instance = instanceNode._tippy
+
+    expect(instance.props.triggerTarget).toBe(instanceNode.parentNode)
+  })
+
   test('component as a child', () => {
     const Child = React.forwardRef(function Comp(_, ref) {
       return <button ref={ref} />


### PR DESCRIPTION
Background
---
Normally, we don't update the Tippy instance's options until the third render, because it is assumed that no options change between the first and second (which is automatic due to `setMounted`())

However, this assumption isn't entirely correct, as attempting to update options via props after the first render but before the second will result in the prop being passed but the option not actually updating. An example of such a case is setting an option with a ref.

Method
---
To fix this, I:
- allow the Tippy instance to update its options on the 2nd render and afterwards instead of the 3rd
- add a test case for updating an option via a ref and asserting that it is set correctly on the second render

Closes #117 