### PR TITLE
Add className support to <TippySingleton />

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ export const tippy: typeof tippyCore;
 
 export interface TippySingletonProps extends Partial<Props> {
   children: Array<React.ReactElement<any>>;
+  className?: string;
 }
 
 export const TippySingleton: React.FunctionComponent<TippySingletonProps>;

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -2,8 +2,12 @@ import React, {forwardRef, cloneElement, useState} from 'react';
 import PropTypes from 'prop-types';
 import {createPortal} from 'react-dom';
 import tippy from 'tippy.js';
-import {preserveRef, ssrSafeCreateDiv, updateClassName} from './utils';
-import {useInstance, useIsomorphicLayoutEffect} from './hooks';
+import {preserveRef, ssrSafeCreateDiv} from './utils';
+import {
+  useInstance,
+  useIsomorphicLayoutEffect,
+  useUpdateClassName,
+} from './hooks';
 
 export function Tippy({
   children,
@@ -83,16 +87,7 @@ export function Tippy({
     }
   });
 
-  // UPDATE className
-  useIsomorphicLayoutEffect(() => {
-    if (className) {
-      const {tooltip} = component.instance.popperChildren;
-      updateClassName(tooltip, 'add', className);
-      return () => {
-        updateClassName(tooltip, 'remove', className);
-      };
-    }
-  }, [className]);
+  useUpdateClassName(component, className);
 
   return (
     <>

--- a/src/TippySingleton.js
+++ b/src/TippySingleton.js
@@ -1,23 +1,36 @@
 import {Children, cloneElement} from 'react';
 import PropTypes from 'prop-types';
 import {createSingleton} from 'tippy.js';
-import {useIsomorphicLayoutEffect, useInstance} from './hooks';
+import {
+  useIsomorphicLayoutEffect,
+  useInstance,
+  useUpdateClassName,
+} from './hooks';
 
-export default function TippySingleton({children, ...props}) {
+export default function TippySingleton({
+  children,
+  className,
+  ignoreAttributes = true,
+  ...restOfNativeProps
+}) {
   const component = useInstance({
     instances: [],
     renders: 1,
   });
 
+  const props = {
+    ignoreAttributes,
+    ...restOfNativeProps,
+  };
+
   useIsomorphicLayoutEffect(() => {
     const {instances} = component;
-    const singleton = createSingleton(instances, props);
+    const instance = createSingleton(instances, props);
 
-    component.singleton = singleton;
+    component.instance = instance;
 
     return () => {
-      singleton.destroy();
-
+      instance.destroy();
       component.instances = instances.filter(i => !i.state.isDestroyed);
     };
   }, [children.length]);
@@ -28,8 +41,10 @@ export default function TippySingleton({children, ...props}) {
       return;
     }
 
-    component.singleton.setProps(props);
+    component.instance.setProps(props);
   });
+
+  useUpdateClassName(component, className);
 
   return Children.map(children, child => {
     return cloneElement(child, {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,5 +1,21 @@
-import {isBrowser} from './utils';
+import {isBrowser, updateClassName} from './utils';
 import {useLayoutEffect, useEffect, useRef} from 'react';
+
+export const useIsomorphicLayoutEffect = isBrowser
+  ? useLayoutEffect
+  : useEffect;
+
+export function useUpdateClassName(component, className) {
+  useIsomorphicLayoutEffect(() => {
+    const {tooltip} = component.instance.popperChildren;
+    if (className) {
+      updateClassName(tooltip, 'add', className);
+      return () => {
+        updateClassName(tooltip, 'remove', className);
+      };
+    }
+  }, [className]);
+}
 
 export function useInstance(initialValue) {
   // Using refs instead of state as it's recommended to not store imperative
@@ -13,7 +29,3 @@ export function useInstance(initialValue) {
 
   return ref.current;
 }
-
-export const useIsomorphicLayoutEffect = isBrowser
-  ? useLayoutEffect
-  : useEffect;


### PR DESCRIPTION
- Since it's its own element, `className` prop support is needed.
- `enabled` and `visible` props don't really make sense for though
- `plugins` prop should be possible but needs to be supported in core, but I don't know if it works properly yet. There's likely conflicts or problems with how it works.