### PR TITLE
Sync className with children changes (create effect)

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -87,7 +87,7 @@ export function Tippy({
     }
   });
 
-  useUpdateClassName(component, className);
+  useUpdateClassName(component, className, children.type);
 
   return (
     <>

--- a/src/TippySingleton.js
+++ b/src/TippySingleton.js
@@ -44,7 +44,7 @@ export default function TippySingleton({
     component.instance.setProps(props);
   });
 
-  useUpdateClassName(component, className);
+  useUpdateClassName(component, className, children.length);
 
   return Children.map(children, child => {
     return cloneElement(child, {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -5,7 +5,7 @@ export const useIsomorphicLayoutEffect = isBrowser
   ? useLayoutEffect
   : useEffect;
 
-export function useUpdateClassName(component, className) {
+export function useUpdateClassName(component, className, childrenDep) {
   useIsomorphicLayoutEffect(() => {
     const {tooltip} = component.instance.popperChildren;
     if (className) {
@@ -14,7 +14,7 @@ export function useUpdateClassName(component, className) {
         updateClassName(tooltip, 'remove', className);
       };
     }
-  }, [className]);
+  }, [className, childrenDep]);
 }
 
 export function useInstance(initialValue) {

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -109,6 +109,24 @@ describe('<Tippy />', () => {
     expect(tooltip.classList.contains('two')).toBe(true);
   });
 
+  test('props.className: syncs with children.type', () => {
+    const {rerender} = render(
+      <Tippy content="tooltip" className="one">
+        <button />
+      </Tippy>,
+    );
+
+    rerender(
+      <Tippy content="tooltip" className="one">
+        <span />
+      </Tippy>,
+    );
+
+    const {tooltip} = instance.popperChildren;
+
+    expect(tooltip.classList.contains('one')).toBe(true);
+  });
+
   test('unmount destroys the tippy instance and allows garbage collection', () => {
     const {container, unmount} = render(
       <Tippy content="tooltip">

--- a/test/TippySingleton.test.js
+++ b/test/TippySingleton.test.js
@@ -196,6 +196,37 @@ describe('<TippySingleton />', () => {
     expect(tooltip.classList.contains('one')).toBe(false);
     expect(tooltip.classList.contains('two')).toBe(true);
   });
+
+  test('props.className: syncs with children.length', () => {
+    const {rerender} = render(
+      <TippySingleton className="one">
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+      </TippySingleton>,
+    );
+
+    rerender(
+      <TippySingleton className="one">
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+      </TippySingleton>,
+    );
+
+    const {tooltip} = instance.popperChildren;
+
+    expect(tooltip.classList.contains('one')).toBe(true);
+  });
 });
 
 describe('TippySingleton.propTypes', () => {


### PR DESCRIPTION
Since the previous instance gets destroyed when `children.type` (`<Tippy />`) and `children.length` (`<TippySingleton />`) change, the `className` never gets applied - we have to add it as a dependency.