### PR TITLE
Use KnownProps to ignore index signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,15 @@ export interface TippySingletonProps extends Partial<KnownProps> {
 
 export const TippySingleton: React.FunctionComponent<TippySingletonProps>;
 
-export type UseSingletonProps = Omit<TippySingletonProps, 'children'>;
+type KnownSingletonProps = Pick<
+  TippySingletonProps,
+  KnownKeys<TippySingletonProps>
+>;
+
+export interface UseSingletonProps
+  extends Omit<KnownSingletonProps, 'children'> {
+  [key: string]: any;
+}
 
 export const useSingleton: (
   props?: UseSingletonProps,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import {default as tippyCore, Instance, Props, Plugin} from 'tippy.js';
 
-export interface TippyProps extends Omit<Partial<Props>, 'content'> {
+type KnownKeys<T> = {
+  [K in keyof T]: string extends K ? never : number extends K ? never : K;
+} extends {[_ in keyof T]: infer U}
+  ? U
+  : never;
+
+export type KnownProps = Pick<Props, KnownKeys<Props>>;
+
+export interface TippyProps extends Omit<Partial<KnownProps>, 'content'> {
   content: React.ReactChild | React.ReactChild[];
   children: React.ReactElement<any>;
   visible?: boolean;
@@ -16,7 +24,7 @@ export default Tippy;
 
 export const tippy: typeof tippyCore;
 
-export interface TippySingletonProps extends Partial<Props> {
+export interface TippySingletonProps extends Partial<KnownProps> {
   children: Array<React.ReactElement<any>>;
   className?: string;
   plugins?: Plugin[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ export interface TippyProps extends Omit<Partial<KnownProps>, 'content'> {
   className?: string;
   plugins?: Plugin[];
   singleton?: (instance: Instance) => void;
+  [key: string]: any;
 }
 
 declare const Tippy: React.ForwardRefExoticComponent<TippyProps>;
@@ -28,6 +29,7 @@ export interface TippySingletonProps extends Partial<KnownProps> {
   children: Array<React.ReactElement<any>>;
   className?: string;
   plugins?: Plugin[];
+  [key: string]: any;
 }
 
 export const TippySingleton: React.FunctionComponent<TippySingletonProps>;


### PR DESCRIPTION
Fixes #134 

This ignores `[key: string]: any` from `Props` interface, allowing autocomplete and type validation to actually work in this package. (It works fine in `tippy.js` core [autocomplete & types validation works] but not when extended here, idk why I'm not good with TS)

--- 

Then we need to add back in the index signature for each of the extended interfaces so plugin props don't error (without needing to make your own type).

To make your own type for plugin props like `followCursor` which don't exist on `Props`, you need to make your own function type, like this, I think:

 ```tsx
import Tippy, {TippyProps} from '@tippy.js/react';
import {followCursor, FollowCursorProps} from 'tippy.js';

const TippyExtended: React.FC<TippyProps & FollowCursorProps> = ({
  plugins,
  ...props
}) => <Tippy plugins={[followCursor, ...(plugins || [])]} {...props} />;
```

BUT since we're adding `[key: string]: any` to each of the extended interfaces, you don't need it just like in `tippy.js` - you just won't get autocompletion & type validation. So it's backwards-compatible with 3.0.0 and 3.0.1.

---

# TL;DR

- Extending an interface with `[key: string]: any` breaks autocomplete & type validation for all the known/declared types, so we need to only extend the KnownProps version of it
- We need to add back `[key: string]: any` to the extended interfaces to prevent unknown props (e.g. for plugins) from erroring. The user can create strict types for plugin props if they wish to. If they pass an unknown prop, there's a runtime DEV warning telling them that, instread of compile time TS warning (for JS users).
- This needs to be done for all `TippyProps`, `TippySingletonProps`, and `UseSingletonProps` interfaces.