### PR TITLE
Support `enabled` prop in singletons

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ export const tippy: typeof tippyCore;
 
 export interface TippySingletonProps extends Partial<KnownProps> {
   children: Array<React.ReactElement<any>>;
+  enabled?: boolean;
   className?: string;
   plugins?: Plugin[];
   [key: string]: any;

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -7,7 +7,7 @@ import {
   useInstance,
   useIsomorphicLayoutEffect,
   useUpdateClassName,
-} from './hooks';
+} from './util-hooks';
 
 export function Tippy({
   children,

--- a/src/util-hooks.js
+++ b/src/util-hooks.js
@@ -1,0 +1,69 @@
+import {isBrowser, updateClassName} from './utils';
+import {useLayoutEffect, useEffect, useRef} from 'react';
+import {createSingleton} from 'tippy.js';
+
+export const useIsomorphicLayoutEffect = isBrowser
+  ? useLayoutEffect
+  : useEffect;
+
+export function useUpdateClassName(component, className, deps) {
+  useIsomorphicLayoutEffect(() => {
+    const {tooltip} = component.instance.popperChildren;
+    if (className) {
+      updateClassName(tooltip, 'add', className);
+      return () => {
+        updateClassName(tooltip, 'remove', className);
+      };
+    }
+  }, [className, ...deps]);
+}
+
+export function useInstance(initialValue) {
+  // Using refs instead of state as it's recommended to not store imperative
+  // values in state due to memory problems in React(?)
+  const ref = useRef();
+
+  if (!ref.current) {
+    ref.current =
+      typeof initialValue === 'function' ? initialValue() : initialValue;
+  }
+
+  return ref.current;
+}
+
+export function useSingletonCreate(component, props, plugins, enabled, deps) {
+  useIsomorphicLayoutEffect(() => {
+    const {instances} = component;
+    const instance = createSingleton(instances, props, plugins);
+
+    component.instance = instance;
+
+    if (!enabled) {
+      instance.disable();
+    }
+
+    return () => {
+      instance.destroy();
+      component.instances = instances.filter(i => !i.state.isDestroyed);
+    };
+  }, deps);
+}
+
+export function useSingletonUpdate(component, props, enabled) {
+  useIsomorphicLayoutEffect(() => {
+    if (component.renders === 1) {
+      component.renders++;
+      return;
+    }
+
+    const {instance} = component;
+
+    instance.setProps(props);
+
+    if (enabled) {
+      instance.enable();
+    } else {
+      instance.disable();
+    }
+  });
+}

--- a/test/TippySingleton.test.js
+++ b/test/TippySingleton.test.js
@@ -228,6 +228,62 @@ describe('<TippySingleton />', () => {
     expect(tooltip.classList.contains('one')).toBe(true);
   });
 
+  test('props.enabled initially `true`', () => {
+    const {rerender} = render(
+      <TippySingleton enabled={true}>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+      </TippySingleton>,
+    );
+
+    expect(instance.state.isEnabled).toBe(true);
+
+    rerender(
+      <TippySingleton enabled={false}>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+      </TippySingleton>,
+    );
+
+    expect(instance.state.isEnabled).toBe(false);
+  });
+
+  test('props.enabled initially `false`', () => {
+    const {rerender} = render(
+      <TippySingleton enabled={false}>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+      </TippySingleton>,
+    );
+
+    expect(instance.state.isEnabled).toBe(false);
+
+    rerender(
+      <TippySingleton enabled={true}>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+        <Tippy content="tooltip">
+          <button />
+        </Tippy>
+      </TippySingleton>,
+    );
+
+    expect(instance.state.isEnabled).toBe(true);
+  });
+
   test('props.plugins', () => {
     const plugins = [{fn: () => ({})}];
 

--- a/test/useSingleton.test.js
+++ b/test/useSingleton.test.js
@@ -202,6 +202,60 @@ describe('The useSingleton hook', () => {
     ).toBe(true);
   });
 
+  test('props.enabled initially `true`', () => {
+    let instance;
+
+    function App({enabled}) {
+      const singleton = useSingleton({
+        enabled,
+        onCreate(i) {
+          instance = i;
+        },
+      });
+
+      return (
+        <Tippy singleton={singleton}>
+          <button />
+        </Tippy>
+      );
+    }
+
+    const {rerender} = render(<App enabled={true} />);
+
+    expect(instance.state.isEnabled).toBe(true);
+
+    rerender(<App enabled={false} />);
+
+    expect(instance.state.isEnabled).toBe(false);
+  });
+
+  test('props.enabled initially `false`', () => {
+    let instance;
+
+    function App({enabled}) {
+      const singleton = useSingleton({
+        enabled,
+        onCreate(i) {
+          instance = i;
+        },
+      });
+
+      return (
+        <Tippy singleton={singleton}>
+          <button />
+        </Tippy>
+      );
+    }
+
+    const {rerender} = render(<App enabled={false} />);
+
+    expect(instance.state.isEnabled).toBe(false);
+
+    rerender(<App enabled={true} />);
+
+    expect(instance.state.isEnabled).toBe(true);
+  });
+
   test('props.plugins', () => {
     const plugins = [{fn: () => ({})}];
 


### PR DESCRIPTION
As I mentioned before, `visible` doesn't make sense for singletons, but `enabled` does. But this brings up an interesting problem: how do you make `visible` or `enabled` work for sub-tippies that are part of the singleton? I think with `group`, that previously worked since they were individual instances. This probably requires changes in core.

Since there's now common code, I've extracted these into separate hooks and created `util-hooks` (used internally) and `hooks` (exported by the package) directories.

