### PR TITLE
fix: extract deps to constant

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -50,6 +50,8 @@ export function Tippy({
     enabled = false;
   }
 
+  const deps = [children.type];
+
   // CREATE
   useIsomorphicLayoutEffect(() => {
     const instance = tippy(component.ref, props, plugins);
@@ -73,7 +75,7 @@ export function Tippy({
     return () => {
       instance.destroy();
     };
-  }, [children.type]);
+  }, deps);
 
   // UPDATE
   useIsomorphicLayoutEffect(() => {
@@ -102,7 +104,7 @@ export function Tippy({
     }
   });
 
-  useUpdateClassName(component, className, children.type);
+  useUpdateClassName(component, className, deps);
 
   return (
     <>

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -5,7 +5,11 @@ import {render, cleanup} from '@testing-library/react';
 afterEach(cleanup);
 
 describe('<Tippy />', () => {
-  let instance;
+  let instance = null;
+
+  afterEach(() => {
+    instance = null;
+  });
 
   function Tippy(props) {
     return <TippyBase {...props} onCreate={i => (instance = i)} />;
@@ -36,7 +40,7 @@ describe('<Tippy />', () => {
       </Tippy>,
     );
 
-    expect(instance).toBeDefined();
+    expect(instance).not.toBeNull();
   });
 
   test('renders react element content inside the content prop', () => {
@@ -236,7 +240,7 @@ describe('<Tippy />', () => {
       </Tippy>,
     );
 
-    expect(instance).toBeDefined();
+    expect(instance).not.toBeNull();
   });
 
   test('refs are preserved on the child', done => {


### PR DESCRIPTION
There was a mistake here as we weren't passing the dep in an array, rather by itself. (We need that TypeScript rewrite asap 😅)

 Babel loose mode uses `className.concat(dep)` so that's why there is no error when using the package (i.e. the dependency array was equivalent to not being there at all - re-running every time for component children since it was concating the forwardRef object), but there's an error in the demo when using a component as a child - not sure why the transform is different there.

It also doesn't error in the tests because of the babel transform, I think.