### PR TITLE
fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ lets you use it declaratively in React.
 
 ```bash
 # npm
-npm i @tippy.js/react
+npm i "@tippy.js/react"
 
 # Yarn
 yarn add @tippy.js/react


### PR DESCRIPTION
If you will try to install tippy using command: npm i @tippy.js/react

You will get error:
```
The splatting operator '@' cannot be used to refer 
ence variables in an expression. '@tippy' can be u 
sed only as an argument to a command. To reference 
 variables in an expression use '$tippy'.
    + CategoryInfo          : ParserError: (:) []  
   , ParentContainsErrorRecordException
    + FullyQualifiedErrorId : SplattingNotPermitt  
   ed
```


Command npm i "@tippy.js/react" have no such problems.