### PR TITLE
Package installation commands updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ lets you use it declaratively in React.
 
 ```bash
 # npm
-npm i @tippy.js/react
+npm i '@tippy.js/react'
 
 # Yarn
-yarn add @tippy.js/react
+yarn add '@tippy.js/react'
 ```
 
 CDN: https://unpkg.com/@tippy.js/react


### PR DESCRIPTION
Added single quotes (') to avoid 'The splatting operator '@' cannot be used to reference variables in an expression.' error when windows users copy and paste the installation commands to PowerShell.

Error message:

```
At line:1 char:10
+ yarn add @tippy.js/react
+          ~~~~~~
The splatting operator '@' cannot be used to reference variables in an expression. '@tippy' can be used only as an argument to a command. To   
reference variables in an expression use '$tippy'.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : SplattingNotPermitted
```
